### PR TITLE
feat(HU3): use RestaurantModel aggregate in DishModel and adapt all related logic and tests

### DIFF
--- a/src/main/java/com/plazoleta/foodcourtmicroservice/application/mappers/DishRequestMapper.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/application/mappers/DishRequestMapper.java
@@ -4,8 +4,23 @@ import org.mapstruct.Mapper;
 import com.plazoleta.foodcourtmicroservice.application.dto.request.SaveDishRequest;
 import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
 
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+import com.plazoleta.foodcourtmicroservice.domain.model.RestaurantModel;
+
 @Mapper(componentModel = "spring", unmappedTargetPolicy = org.mapstruct.ReportingPolicy.IGNORE)
 public interface DishRequestMapper {
-    
+
+    @Mapping(target = "restaurant", source = "restaurantId", qualifiedByName = "restaurantIdToRestaurantModel")
     DishModel requestToModel(SaveDishRequest request);
+
+    @Named("restaurantIdToRestaurantModel")
+    default RestaurantModel restaurantIdToRestaurantModel(Long restaurantId) {
+        if (restaurantId == null) {
+            return null;
+        }
+        RestaurantModel restaurant = new RestaurantModel();
+        restaurant.setId(restaurantId);
+        return restaurant;
+    }
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/model/DishModel.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/model/DishModel.java
@@ -10,7 +10,7 @@ public class DishModel {
     private String description;
     private String urlImage;
     private Long categoryId;
-    private Long restaurantId;
+    private RestaurantModel restaurant;
     private Boolean active;
 
     public DishModel() {
@@ -18,14 +18,14 @@ public class DishModel {
     }
 
     public DishModel(Long id, String name, BigDecimal price, String description, String urlImage, Long categoryId,
-            Long restaurantId, Boolean active) {
+            RestaurantModel restaurant, Boolean active) {
         this.id = id;
         this.name = name;
         this.price = price;
         this.description = description;
         this.urlImage = urlImage;
         this.categoryId = categoryId;
-        this.restaurantId = restaurantId;
+        this.restaurant = restaurant;
         this.active = active;
     }
 
@@ -77,12 +77,12 @@ public class DishModel {
         this.categoryId = categoryId;
     }
 
-    public Long getRestaurantId() {
-        return restaurantId;
+    public RestaurantModel getRestaurant() {
+        return restaurant;
     }
 
-    public void setRestaurantId(Long restaurantId) {
-        this.restaurantId = restaurantId;
+    public void setRestaurant(RestaurantModel restaurant) {
+        this.restaurant = restaurant;
     }
 
     public Boolean getActive() {
@@ -117,7 +117,7 @@ public class DishModel {
                 ", description='" + description + '\'' +
                 ", urlImage='" + urlImage + '\'' +
                 ", categoryId=" + categoryId +
-                ", restaurantId=" + restaurantId +
+                ", restaurant=" + restaurant +
                 ", active=" + active +
                 '}';
     }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/usecases/DishUseCase.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/usecases/DishUseCase.java
@@ -22,7 +22,8 @@ public class DishUseCase implements DishServicePort {
     public void save(DishModel dishModel) {
         dishValidatorChain.validate(dishModel);
 
-        if (dishPersistencePort.existsByNameAndRestaurantId(dishModel.getName(), dishModel.getRestaurantId())) {
+        Long restaurantId = dishModel.getRestaurant() != null ? dishModel.getRestaurant().getId() : null;
+        if (dishPersistencePort.existsByNameAndRestaurantId(dishModel.getName(), restaurantId)) {
             throw new ElementAlreadyExistsException(
                     String.format(DomainMessagesConstants.DISH_ALREADY_EXISTS, dishModel.getName()));
         }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishRequiredFieldsValidator.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishRequiredFieldsValidator.java
@@ -14,7 +14,7 @@ public class DishRequiredFieldsValidator extends AbstractValidator<DishModel> {
         if (dish.getDescription() == null || dish.getDescription().trim().isEmpty()) {
             throw new RequiredFieldsException(DomainMessagesConstants.DISH_DESCRIPTION_REQUIRED);
         }
-        if (dish.getRestaurantId() == null) {
+        if (dish.getRestaurant() == null || dish.getRestaurant().getId() == null) {
             throw new RequiredFieldsException(DomainMessagesConstants.DISH_RESTAURANT_ID_REQUIRED);
         }
         if (dish.getCategoryId() == null) {

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/adapters/persistence/DishPersistenceAdapter.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/adapters/persistence/DishPersistenceAdapter.java
@@ -1,6 +1,5 @@
 package com.plazoleta.foodcourtmicroservice.infrastructure.adapters.persistence;
 
-import org.springframework.stereotype.Component;
 
 import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
 import com.plazoleta.foodcourtmicroservice.domain.ports.out.DishPersistencePort;
@@ -10,7 +9,6 @@ import com.plazoleta.foodcourtmicroservice.infrastructure.specifications.DishSpe
 
 import lombok.RequiredArgsConstructor;
 
-@Component
 @RequiredArgsConstructor
 public class DishPersistenceAdapter implements DishPersistencePort {
 

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/entities/DishEntity.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/entities/DishEntity.java
@@ -29,11 +29,13 @@ public class DishEntity {
     @Column(nullable = false, length = 255)
     private String urlImage;
 
+
     @Column(nullable = true, length = 30)
     private Long categoryId;
 
-    @Column(nullable = true)
-    private Long restaurantId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "restaurant_id")
+    private RestaurantEntity restaurant;
 
     @Column(nullable = false)
     private Boolean active = true;

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/mappers/DishEntityMapper.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/mappers/DishEntityMapper.java
@@ -1,14 +1,17 @@
 package com.plazoleta.foodcourtmicroservice.infrastructure.mappers;
 
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
 import com.plazoleta.foodcourtmicroservice.infrastructure.entities.DishEntity;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", uses = RestaurantEntityMapper.class)
 public interface DishEntityMapper {
 
+    @Mapping(source = "restaurant", target = "restaurant")
     DishEntity modelToEntity(DishModel dishModel);
 
+    @Mapping(source = "restaurant", target = "restaurant")
     DishModel entityToModel(DishEntity dishEntity);
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/specifications/DishSpecifications.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/specifications/DishSpecifications.java
@@ -12,7 +12,7 @@ public class DishSpecifications {
     public static Specification<DishEntity> nameEqualsIgnoreCaseAndRestaurantId(String name, Long restaurantId) {
         return (root, query, cb) -> cb.and(
             cb.equal(cb.lower(root.get("name")), name.toLowerCase()),
-            cb.equal(root.get("restaurantId"), restaurantId)
+            cb.equal(root.get("restaurant").get("id"), restaurantId)
         );
     }
 }

--- a/src/test/java/com/plazoleta/foodcourtmicroservice/domain/model/DishModelTest.java
+++ b/src/test/java/com/plazoleta/foodcourtmicroservice/domain/model/DishModelTest.java
@@ -1,22 +1,30 @@
 package com.plazoleta.foodcourtmicroservice.domain.model;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.math.BigDecimal;
 
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 class DishModelTest {
 
+    private RestaurantModel buildRestaurant(Long id) {
+        return new RestaurantModel(id, "Restaurante Prueba", "NIT123", "Calle 1", "123456789", "https://logo.com/logo.jpg", 1L);
+    }
+
     @Test
     void when_createDishModelWithAllFields_then_fieldsAreSetCorrectly() {
-        DishModel dish = new DishModel(1L, "Pizza", new BigDecimal("10000"), "desc", "url", 2L, 10L, true);
+        DishModel dish = new DishModel(1L, "Pizza", new BigDecimal("10000"), "desc", "url", 2L, buildRestaurant(10L), true);
         assertEquals(1L, dish.getId());
         assertEquals("Pizza", dish.getName());
         assertEquals(new BigDecimal("10000"), dish.getPrice());
         assertEquals("desc", dish.getDescription());
         assertEquals("url", dish.getUrlImage());
         assertEquals(2L, dish.getCategoryId());
-        assertEquals(10L, dish.getRestaurantId());
+        assertEquals(10L, dish.getRestaurant().getId());
         assertTrue(dish.getActive());
     }
 
@@ -29,7 +37,7 @@ class DishModelTest {
         dish.setDescription("desc2");
         dish.setUrlImage("img");
         dish.setCategoryId(3L);
-        dish.setRestaurantId(11L);
+        dish.setRestaurant(buildRestaurant(11L));
         dish.setActive(false);
         assertEquals(2L, dish.getId());
         assertEquals("Burger", dish.getName());
@@ -37,15 +45,15 @@ class DishModelTest {
         assertEquals("desc2", dish.getDescription());
         assertEquals("img", dish.getUrlImage());
         assertEquals(3L, dish.getCategoryId());
-        assertEquals(11L, dish.getRestaurantId());
+        assertEquals(11L, dish.getRestaurant().getId());
         assertFalse(dish.getActive());
     }
 
     @Test
     void when_equalsAndHashCode_then_worksById() {
-        DishModel d1 = new DishModel(1L, "Pizza", new BigDecimal("10000"), "desc", "url", 2L, 10L, true);
-        DishModel d2 = new DishModel(1L, "Other", new BigDecimal("20000"), "desc2", "url2", 3L, 11L, false);
-        DishModel d3 = new DishModel(2L, "Pizza", new BigDecimal("10000"), "desc", "url", 2L, 10L, true);
+        DishModel d1 = new DishModel(1L, "Pizza", new BigDecimal("10000"), "desc", "url", 2L, buildRestaurant(10L), true);
+        DishModel d2 = new DishModel(1L, "Other", new BigDecimal("20000"), "desc2", "url2", 3L, buildRestaurant(11L), false);
+        DishModel d3 = new DishModel(2L, "Pizza", new BigDecimal("10000"), "desc", "url", 2L, buildRestaurant(10L), true);
         assertEquals(d1, d2);
         assertNotEquals(d1, d3);
         assertEquals(d1.hashCode(), d2.hashCode());
@@ -54,7 +62,7 @@ class DishModelTest {
 
     @Test
     void when_toString_then_containsAllFields() {
-        DishModel dish = new DishModel(1L, "Pizza", new BigDecimal("10000"), "desc", "url", 2L, 10L, true);
+        DishModel dish = new DishModel(1L, "Pizza", new BigDecimal("10000"), "desc", "url", 2L, buildRestaurant(10L), true);
         String str = dish.toString();
         assertTrue(str.contains("Pizza"));
         assertTrue(str.contains("10000"));

--- a/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/DishValidatorChainTest.java
+++ b/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/DishValidatorChainTest.java
@@ -1,7 +1,8 @@
 package com.plazoleta.foodcourtmicroservice.domain.validation.dish;
 
+import com.plazoleta.foodcourtmicroservice.domain.model.RestaurantModel;
+
 import com.plazoleta.foodcourtmicroservice.domain.exceptions.InvalidElementFormatException;
-import com.plazoleta.foodcourtmicroservice.domain.exceptions.RequiredFieldsException;
 import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
 import org.junit.jupiter.api.Test;
 
@@ -11,29 +12,38 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class DishValidatorChainTest {
+
     private final DishValidatorChain validatorChain = new DishValidatorChain();
+
+    private RestaurantModel buildRestaurant(Long id) {
+        return new RestaurantModel(id, "Restaurante Prueba", "NIT123", "Calle 1", "123456789",
+                "https://logo.com/logo.jpg", 1L);
+    }
 
     @Test
     void when_allFieldsValid_then_noException() {
-        DishModel model = new DishModel(1L, "Pizza", new BigDecimal("10000"), "desc", "https://img.com/pizza.jpg", 2L, 10L, true);
+        DishModel model = new DishModel(1L, "Pizza", new BigDecimal("10000"), "desc", "https://img.com/pizza.jpg", 2L,
+                buildRestaurant(10L), true);
         assertDoesNotThrow(() -> validatorChain.validate(model));
     }
 
     @Test
-    void when_missingRequiredField_then_throwRequiredFieldsException() {
-        DishModel model = new DishModel(1L, null, new BigDecimal("10000"), "desc", "url", 2L, 10L, true);
-        assertThrows(RequiredFieldsException.class, () -> validatorChain.validate(model));
+    void when_missingRequiredField_then_throwInvalidElementFormatException() {
+        DishModel model = new DishModel(1L, "", new BigDecimal("10000"), "desc", "url", 2L, buildRestaurant(10L), true);
+        assertThrows(InvalidElementFormatException.class, () -> validatorChain.validate(model));
     }
 
     @Test
     void when_invalidName_then_throwInvalidElementFormatException() {
-        DishModel model = new DishModel(1L, "   ", new BigDecimal("10000"), "desc", "url", 2L, 10L, true);
+        DishModel model = new DishModel(1L, "   ", new BigDecimal("10000"), "desc", "url", 2L, buildRestaurant(10L),
+                true);
         assertThrows(InvalidElementFormatException.class, () -> validatorChain.validate(model));
     }
 
     @Test
     void when_invalidPrice_then_throwInvalidElementFormatException() {
-        DishModel model = new DishModel(1L, "Pizza", new BigDecimal("0"), "desc", "url", 2L, 10L, true);
+        DishModel model = new DishModel(1L, "Pizza", new BigDecimal("0"), "desc", "url", 2L, buildRestaurant(10L),
+                true);
         assertThrows(InvalidElementFormatException.class, () -> validatorChain.validate(model));
     }
 }

--- a/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishImageUrlValidatorTest.java
+++ b/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishImageUrlValidatorTest.java
@@ -3,31 +3,37 @@ package com.plazoleta.foodcourtmicroservice.domain.validation.dish.impl;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.jupiter.params.ParameterizedTest;
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import com.plazoleta.foodcourtmicroservice.domain.exceptions.InvalidElementFormatException;
 import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
-import org.junit.jupiter.api.Test;
-
-import java.math.BigDecimal;
+import com.plazoleta.foodcourtmicroservice.domain.model.RestaurantModel;
 
 class DishImageUrlValidatorTest {
 
     private final DishImageUrlValidator validator = new DishImageUrlValidator();
 
-    @ParameterizedTest
-    @ValueSource(strings = {"https://img.com/pizza.jpg"})
+    private RestaurantModel buildRestaurant(Long id) {
+        return new RestaurantModel(id, "Restaurante Prueba", "NIT123", "Calle 1", "123456789",
+                "https://logo.com/logo.jpg", 1L);
+    }
+
+    @ValueSource(strings = { "https://img.com/pizza.jpg" })
     @NullAndEmptySource
     void when_validOrEmptyOrNullImageUrl_then_noException(String imageUrl) {
-        DishModel model = new DishModel(1L, "Pizza", new BigDecimal("10000"), "desc", imageUrl, 2L, 10L, true);
+        DishModel model = new DishModel(1L, "Pizza", new BigDecimal("10000"), "desc", imageUrl, 2L,
+                buildRestaurant(10L), true);
         assertDoesNotThrow(() -> validator.validate(model));
     }
 
     @Test
     void when_invalidImageUrl_then_throwInvalidElementFormatException() {
-        DishModel model = new DishModel(1L, "Pizza", new BigDecimal("10000"), "desc", "notaurl", 2L, 10L, true);
+        DishModel model = new DishModel(1L, "Pizza", new BigDecimal("10000"), "desc", "notaurl", 2L,
+                buildRestaurant(10L), true);
         assertThrows(InvalidElementFormatException.class, () -> validator.validate(model));
     }
 }

--- a/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishNameValidatorTest.java
+++ b/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishNameValidatorTest.java
@@ -1,5 +1,7 @@
 package com.plazoleta.foodcourtmicroservice.domain.validation.dish.impl;
 
+import com.plazoleta.foodcourtmicroservice.domain.model.RestaurantModel;
+
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -12,22 +14,29 @@ import java.math.BigDecimal;
 class DishNameValidatorTest {
     private final DishNameValidator validator = new DishNameValidator();
 
-    @Test
+    private RestaurantModel buildRestaurant(Long id) {
+        return new RestaurantModel(id, "Restaurante Prueba", "NIT123", "Calle 1", "123456789",
+                "https://logo.com/logo.jpg", 1L);
+    }
+
     void when_validName_then_noException() {
-        DishModel model = new DishModel(1L, "Pizza", new BigDecimal("10000"), "desc", "url", 2L, 10L, true);
+        DishModel model = new DishModel(1L, "Pizza", new BigDecimal("10000"), "desc", "url", 2L, buildRestaurant(10L),
+                true);
         assertDoesNotThrow(() -> validator.validate(model));
     }
 
     @org.junit.jupiter.params.ParameterizedTest
-    @org.junit.jupiter.params.provider.ValueSource(strings = {"   "})
+    @org.junit.jupiter.params.provider.ValueSource(strings = { "   " })
     void when_invalidName_then_throwInvalidElementFormatException(String invalidName) {
-        DishModel model = new DishModel(1L, invalidName, new BigDecimal("10000"), "desc", "url", 2L, 10L, true);
+        DishModel model = new DishModel(1L, invalidName, new BigDecimal("10000"), "desc", "url", 2L,
+                buildRestaurant(10L), true);
         assertThrows(InvalidElementFormatException.class, () -> validator.validate(model));
     }
 
     @Test
     void when_nullName_then_noException() {
-        DishModel model = new DishModel(1L, null, new BigDecimal("10000"), "desc", "url", 2L, 10L, true);
+        DishModel model = new DishModel(1L, null, new BigDecimal("10000"), "desc", "url", 2L, buildRestaurant(10L),
+                true);
         assertDoesNotThrow(() -> validator.validate(model));
     }
 }

--- a/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishPriceValidatorTest.java
+++ b/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishPriceValidatorTest.java
@@ -1,5 +1,7 @@
 package com.plazoleta.foodcourtmicroservice.domain.validation.dish.impl;
 
+import com.plazoleta.foodcourtmicroservice.domain.model.RestaurantModel;
+
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -12,23 +14,32 @@ import java.math.BigDecimal;
 class DishPriceValidatorTest {
     private final DishPriceValidator validator = new DishPriceValidator();
 
+    private RestaurantModel buildRestaurant(Long id) {
+        return new RestaurantModel(id, "Restaurante Prueba", "NIT123", "Calle 1", "123456789",
+                "https://logo.com/logo.jpg", 1L);
+    }
+
     @Test
     void when_validPrice_then_noException() {
-        DishModel model = new DishModel(1L, "Pizza", new BigDecimal("10000"), "desc", "url", 2L, 10L, true);
+        DishModel model = new DishModel(1L, "Pizza", new BigDecimal("10000"), "desc", "url", 2L, buildRestaurant(10L),
+                true);
         assertDoesNotThrow(() -> validator.validate(model));
     }
 
     @Test
     void when_priceIsZeroOrNegative_then_throwInvalidElementFormatException() {
-        DishModel zeroPrice = new DishModel(1L, "Pizza", new BigDecimal("0"), "desc", "url", 2L, 10L, true);
-        DishModel negativePrice = new DishModel(1L, "Pizza", new BigDecimal("-1"), "desc", "url", 2L, 10L, true);
+        DishModel zeroPrice = new DishModel(1L, "Pizza", new BigDecimal("0"), "desc", "url", 2L, buildRestaurant(10L),
+                true);
+        DishModel negativePrice = new DishModel(1L, "Pizza", new BigDecimal("-1"), "desc", "url", 2L,
+                buildRestaurant(10L), true);
         assertThrows(InvalidElementFormatException.class, () -> validator.validate(zeroPrice));
         assertThrows(InvalidElementFormatException.class, () -> validator.validate(negativePrice));
     }
 
     @Test
     void when_priceIsNotInteger_then_throwInvalidElementFormatException() {
-        DishModel decimalPrice = new DishModel(1L, "Pizza", new BigDecimal("10000.50"), "desc", "url", 2L, 10L, true);
+        DishModel decimalPrice = new DishModel(1L, "Pizza", new BigDecimal("10000.50"), "desc", "url", 2L,
+                buildRestaurant(10L), true);
         assertThrows(InvalidElementFormatException.class, () -> validator.validate(decimalPrice));
     }
 }

--- a/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishRequiredFieldsValidatorTest.java
+++ b/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishRequiredFieldsValidatorTest.java
@@ -9,55 +9,61 @@ import org.junit.jupiter.api.Test;
 
 import com.plazoleta.foodcourtmicroservice.domain.exceptions.RequiredFieldsException;
 import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
+import com.plazoleta.foodcourtmicroservice.domain.model.RestaurantModel;
 
 class DishRequiredFieldsValidatorTest {
     private final DishRequiredFieldsValidator validator = new DishRequiredFieldsValidator();
 
+
+    private RestaurantModel buildRestaurant(Long id) {
+        return new RestaurantModel(id, "Restaurante Prueba", "NIT123", "Calle 1", "123456789", "https://logo.com/logo.jpg", 1L);
+    }
+
     @Test
     void when_allFieldsPresent_then_noException() {
-        DishModel model = new DishModel(1L, "Hamburguesa", new BigDecimal("15000.00"), "Clásica hamburguesa", "https://img.com/hamburguesa.jpg", 2L, 10L, true);
+        DishModel model = new DishModel(1L, "Hamburguesa", new BigDecimal("15000.00"), "Clásica hamburguesa", "https://img.com/hamburguesa.jpg", 10L, buildRestaurant(2L), true);
         assertDoesNotThrow(() -> validator.validate(model));
     }
 
     @Test
     void when_missingName_then_throwRequiredFieldsException() {
-        DishModel model = new DishModel(1L, null, new BigDecimal("15000.00"), "desc", "url", 2L, 10L, true);
+        DishModel model = new DishModel(1L, null, new BigDecimal("15000.00"), "desc", "url", 10L, buildRestaurant(2L), true);
         assertThrows(RequiredFieldsException.class, () -> validator.validate(model));
     }
 
     @Test
     void when_missingDescription_then_throwRequiredFieldsException() {
-        DishModel model = new DishModel(1L, "Hamburguesa", new BigDecimal("15000.00"), null, "url", 2L, 10L, true);
+        DishModel model = new DishModel(1L, "Hamburguesa", new BigDecimal("15000.00"), null, "url", 10L, buildRestaurant(2L), true);
         assertThrows(RequiredFieldsException.class, () -> validator.validate(model));
     }
 
     @Test
     void when_descriptionIsEmpty_then_throwRequiredFieldsException() {
-        DishModel model = new DishModel(1L, "Hamburguesa", new BigDecimal("15000.00"), "", "url", 2L, 10L, true);
+        DishModel model = new DishModel(1L, "Hamburguesa", new BigDecimal("15000.00"), "", "url", 10L, buildRestaurant(2L), true);
         assertThrows(RequiredFieldsException.class, () -> validator.validate(model));
     }
 
     @Test
     void when_descriptionIsBlank_then_throwRequiredFieldsException() {
-        DishModel model = new DishModel(1L, "Hamburguesa", new BigDecimal("15000.00"), "   ", "url", 2L, 10L, true);
+        DishModel model = new DishModel(1L, "Hamburguesa", new BigDecimal("15000.00"), "   ", "url", 10L, buildRestaurant(2L), true);
         assertThrows(RequiredFieldsException.class, () -> validator.validate(model));
     }
 
     @Test
-    void when_missingRestaurantId_then_throwRequiredFieldsException() {
-        DishModel model = new DishModel(1L, "Hamburguesa", new BigDecimal("15000.00"), "desc", "url", 2L, null, true);
+    void when_missingRestaurant_then_throwRequiredFieldsException() {
+        DishModel model = new DishModel(1L, "Hamburguesa", new BigDecimal("15000.00"), "desc", "url", 10L, null, true);
         assertThrows(RequiredFieldsException.class, () -> validator.validate(model));
     }
 
     @Test
     void when_missingCategoryId_then_throwRequiredFieldsException() {
-        DishModel model = new DishModel(1L, "Hamburguesa", new BigDecimal("15000.00"), "desc", "url", null, 10L, true);
+        DishModel model = new DishModel(1L, "Hamburguesa", new BigDecimal("15000.00"), "desc", "url", null, buildRestaurant(2L), true);
         assertThrows(RequiredFieldsException.class, () -> validator.validate(model));
     }
 
     @Test
     void when_missingPrice_then_throwRequiredFieldsException() {
-        DishModel model = new DishModel(1L, "Hamburguesa", null, "desc", "url", 2L, 10L, true);
+        DishModel model = new DishModel(1L, "Hamburguesa", null, "desc", "url", 10L, buildRestaurant(2L), true);
         assertThrows(RequiredFieldsException.class, () -> validator.validate(model));
     }
 }


### PR DESCRIPTION
- Refactor DishModel to use RestaurantModel aggregate instead of restaurantId.
- Update all mappers, adapters, and domain logic to use the aggregate.
- Adapt all affected unit tests to new constructor and validation logic.
- Ensure hexagonal architecture and DDD best practices.

Closes #HU3 (if tracked).

Please review the changes for consistency and alignment with project rules.