### PR TITLE
feat(restaurant): create restaurant use case and fix bean duplication

### DIFF
--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/adapters/persistence/RestaurantPersistenceAdapter.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/adapters/persistence/RestaurantPersistenceAdapter.java
@@ -1,7 +1,5 @@
 package com.plazoleta.foodcourtmicroservice.infrastructure.adapters.persistence;
 
-import org.springframework.stereotype.Repository;
-
 import com.plazoleta.foodcourtmicroservice.domain.model.RestaurantModel;
 import com.plazoleta.foodcourtmicroservice.domain.ports.out.RestaurantPersistencePort;
 import com.plazoleta.foodcourtmicroservice.infrastructure.mappers.RestaurantEntityMapper;
@@ -9,7 +7,6 @@ import com.plazoleta.foodcourtmicroservice.infrastructure.repositories.postgres.
 
 import lombok.RequiredArgsConstructor;
 
-@Repository
 @RequiredArgsConstructor
 public class RestaurantPersistenceAdapter implements RestaurantPersistencePort {
 


### PR DESCRIPTION
- Implement restaurant creation use case following hexagonal architecture.
- Remove @Repository from RestaurantPersistenceAdapter to avoid bean duplication.
- Adapt domain, adapters, configuration and tests to new structure.
- Ensure compatibility with aggregate RestaurantModel in DishModel.
- All tests passing and code reviewed for consistency.

Ready for review and merge into develop.