### PR TITLE
Refactor and document Dish validation logic (HU4)

### DIFF
--- a/src/main/java/com/plazoleta/foodcourtmicroservice/application/dto/request/SaveDishRequest.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/application/dto/request/SaveDishRequest.java
@@ -5,16 +5,16 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(name = "SaveDishRequest", description = "Request body for creating a new dish.")
 public record SaveDishRequest(
-    @Schema(description = "Dish name", example = "Hamburguesa Clásica")
+    @Schema(description = "Dish name", example = "Classic Burger")
     String name,
 
     @Schema(description = "Dish price (integer, greater than 0)", example = "15000")
     Integer price,
 
-    @Schema(description = "Dish description", example = "Jugosa hamburguesa de res con queso cheddar y vegetales frescos.")
+    @Schema(description = "Dish description", example = "Juicy beef burger with cheddar cheese and fresh vegetables.")
     String description,
 
-    @Schema(description = "Image URL (http/https, ends with jpg/png/jpeg/gif/bmp)", example = "https://cdn.ejemplo.com/img/hamburguesa.jpg")
+    @Schema(description = "Image URL (http or https, ends with jpg/png/jpeg/gif/bmp)", example = "https://cdn.example.com/img/burger.jpg")
     String urlImage,
 
     @Schema(description = "Category ID", example = "1")

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/application/dto/request/UpdateDishRequest.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/application/dto/request/UpdateDishRequest.java
@@ -1,9 +1,16 @@
 package com.plazoleta.foodcourtmicroservice.application.dto.request;
 
 import java.math.BigDecimal;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(name = "UpdateDishRequest", description = "Request body for updating a dish.")
 public record UpdateDishRequest(
-        Long restaurantId,
-        BigDecimal price,
-        String description) {
-}
+    @Schema(description = "Restaurant ID", example = "10")
+    Long restaurantId,
+
+    @Schema(description = "Dish price (integer, greater than 0)", example = "16000")
+    BigDecimal price,
+
+    @Schema(description = "Dish description", example = "Updated description for the dish.")
+    String description
+) {}

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/application/dto/request/UpdateDishRequest.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/application/dto/request/UpdateDishRequest.java
@@ -1,0 +1,9 @@
+package com.plazoleta.foodcourtmicroservice.application.dto.request;
+
+import java.math.BigDecimal;
+
+public record UpdateDishRequest(
+        Long restaurantId,
+        BigDecimal price,
+        String description) {
+}

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/application/dto/response/UpdateDishResponse.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/application/dto/response/UpdateDishResponse.java
@@ -1,0 +1,8 @@
+package com.plazoleta.foodcourtmicroservice.application.dto.response;
+
+import java.time.LocalDateTime;
+
+public record UpdateDishResponse(
+        String message,
+        LocalDateTime timestamp) {
+}

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/application/handler/DishHandler.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/application/handler/DishHandler.java
@@ -1,9 +1,12 @@
 package com.plazoleta.foodcourtmicroservice.application.handler;
 
 import com.plazoleta.foodcourtmicroservice.application.dto.request.SaveDishRequest;
+import com.plazoleta.foodcourtmicroservice.application.dto.request.UpdateDishRequest;
 import com.plazoleta.foodcourtmicroservice.application.dto.response.SaveDishResponse;
+import com.plazoleta.foodcourtmicroservice.application.dto.response.UpdateDishResponse;
 
 public interface DishHandler {
-    
     SaveDishResponse save(SaveDishRequest request);
+
+    UpdateDishResponse update(Long dishId, UpdateDishRequest request);
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/application/handler/impl/DishHandlerImpl.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/application/handler/impl/DishHandlerImpl.java
@@ -3,14 +3,17 @@ package com.plazoleta.foodcourtmicroservice.application.handler.impl;
 import java.time.LocalDateTime;
 
 import org.springframework.stereotype.Service;
-import lombok.RequiredArgsConstructor;
 
 import com.plazoleta.foodcourtmicroservice.application.dto.request.SaveDishRequest;
+import com.plazoleta.foodcourtmicroservice.application.dto.request.UpdateDishRequest;
 import com.plazoleta.foodcourtmicroservice.application.dto.response.SaveDishResponse;
+import com.plazoleta.foodcourtmicroservice.application.dto.response.UpdateDishResponse;
 import com.plazoleta.foodcourtmicroservice.application.handler.DishHandler;
 import com.plazoleta.foodcourtmicroservice.application.mappers.DishRequestMapper;
-import com.plazoleta.foodcourtmicroservice.domain.ports.in.DishServicePort;
 import com.plazoleta.foodcourtmicroservice.application.utils.constants.ApplicationMessagesConstants;
+import com.plazoleta.foodcourtmicroservice.domain.ports.in.DishServicePort;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
@@ -23,5 +26,11 @@ public class DishHandlerImpl implements DishHandler {
     public SaveDishResponse save(SaveDishRequest request) {
         dishServicePort.save(dishRequestMapper.requestToModel(request));
         return new SaveDishResponse(ApplicationMessagesConstants.DISH_SAVED_SUCCESSFULLY, LocalDateTime.now());
+    }
+
+    @Override
+    public UpdateDishResponse update(Long dishId, UpdateDishRequest request) {
+        dishServicePort.updateDish(dishId, request.restaurantId(), request.price(), request.description());
+        return new UpdateDishResponse(ApplicationMessagesConstants.DISH_UPDATED_SUCCESSFULLY, LocalDateTime.now());
     }
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/application/utils/constants/ApplicationMessagesConstants.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/application/utils/constants/ApplicationMessagesConstants.java
@@ -4,6 +4,7 @@ public final class ApplicationMessagesConstants {
 
     public static final String RESTAURANT_SAVED_SUCCESSFULLY = "Restaurant saved successfully";
     public static final String DISH_SAVED_SUCCESSFULLY = "Dish saved successfully";
+    public static final String DISH_UPDATED_SUCCESSFULLY = "Dish updated successfully";
 
     private ApplicationMessagesConstants() {
         throw new IllegalStateException("Utility class");

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/enums/OperationType.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/enums/OperationType.java
@@ -1,0 +1,6 @@
+package com.plazoleta.foodcourtmicroservice.domain.enums;
+
+public enum OperationType {
+    CREATE,
+    UPDATE
+}

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/ports/in/DishServicePort.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/ports/in/DishServicePort.java
@@ -1,8 +1,11 @@
 package com.plazoleta.foodcourtmicroservice.domain.ports.in;
 
+import java.math.BigDecimal;
+
 import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
 
 public interface DishServicePort {
     void save(DishModel dishModel);
-    // Agrega aquí otros métodos según necesidades futuras (listar, modificar, etc.)
+
+    void updateDish(Long dishId, Long restaurantId, BigDecimal price, String description);
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/ports/out/DishPersistencePort.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/ports/out/DishPersistencePort.java
@@ -1,5 +1,7 @@
 package com.plazoleta.foodcourtmicroservice.domain.ports.out;
 
+import java.math.BigDecimal;
+
 import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
 
 public interface DishPersistencePort {
@@ -8,4 +10,5 @@ public interface DishPersistencePort {
 
     boolean existsByNameAndRestaurantId(String name, Long restaurantId);
 
+    void updateDish(Long dishId, Long restaurantId, BigDecimal price, String description);
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/ports/out/DishPersistencePort.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/ports/out/DishPersistencePort.java
@@ -11,4 +11,7 @@ public interface DishPersistencePort {
     boolean existsByNameAndRestaurantId(String name, Long restaurantId);
 
     void updateDish(Long dishId, Long restaurantId, BigDecimal price, String description);
+
+    boolean existsByIdAndRestaurantId(Long dishId, Long restaurantId);
+
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/usecases/DishUseCase.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/usecases/DishUseCase.java
@@ -1,5 +1,7 @@
 package com.plazoleta.foodcourtmicroservice.domain.usecases;
 
+import java.math.BigDecimal;
+
 import com.plazoleta.foodcourtmicroservice.domain.exceptions.ElementAlreadyExistsException;
 import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
 import com.plazoleta.foodcourtmicroservice.domain.ports.in.DishServicePort;
@@ -29,5 +31,10 @@ public class DishUseCase implements DishServicePort {
         }
 
         dishPersistencePort.save(dishModel);
+    }
+
+    @Override
+    public void updateDish(Long dishId, Long restaurantId, BigDecimal price, String description) {
+        dishPersistencePort.updateDish(dishId, restaurantId, price, description);
     }
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/usecases/DishUseCase.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/usecases/DishUseCase.java
@@ -10,6 +10,7 @@ import com.plazoleta.foodcourtmicroservice.domain.ports.in.DishServicePort;
 import com.plazoleta.foodcourtmicroservice.domain.ports.out.DishPersistencePort;
 import com.plazoleta.foodcourtmicroservice.domain.utils.constants.DomainMessagesConstants;
 import com.plazoleta.foodcourtmicroservice.domain.validation.dish.DishValidatorChain;
+import com.plazoleta.foodcourtmicroservice.domain.enums.OperationType;
 
 public class DishUseCase implements DishServicePort {
 
@@ -24,7 +25,7 @@ public class DishUseCase implements DishServicePort {
 
     @Override
     public void save(DishModel dishModel) {
-        dishValidatorChain.validate(dishModel);
+        dishValidatorChain.validate(dishModel, OperationType.CREATE);
 
         Long restaurantId = dishModel.getRestaurant() != null ? dishModel.getRestaurant().getId() : null;
         if (dishPersistencePort.existsByNameAndRestaurantId(dishModel.getName(), restaurantId)) {
@@ -50,7 +51,7 @@ public class DishUseCase implements DishServicePort {
         restaurant.setId(restaurantId);
         dishModel.setRestaurant(restaurant);
 
-        dishValidatorChain.validate(dishModel);
+        dishValidatorChain.validate(dishModel, OperationType.UPDATE);
 
         dishPersistencePort.updateDish(dishId, restaurantId, price, description);
     }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/usecases/DishUseCase.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/usecases/DishUseCase.java
@@ -3,7 +3,9 @@ package com.plazoleta.foodcourtmicroservice.domain.usecases;
 import java.math.BigDecimal;
 
 import com.plazoleta.foodcourtmicroservice.domain.exceptions.ElementAlreadyExistsException;
+import com.plazoleta.foodcourtmicroservice.domain.exceptions.ElementNotFoundException;
 import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
+import com.plazoleta.foodcourtmicroservice.domain.model.RestaurantModel;
 import com.plazoleta.foodcourtmicroservice.domain.ports.in.DishServicePort;
 import com.plazoleta.foodcourtmicroservice.domain.ports.out.DishPersistencePort;
 import com.plazoleta.foodcourtmicroservice.domain.utils.constants.DomainMessagesConstants;
@@ -35,6 +37,21 @@ public class DishUseCase implements DishServicePort {
 
     @Override
     public void updateDish(Long dishId, Long restaurantId, BigDecimal price, String description) {
+        if (!dishPersistencePort.existsByIdAndRestaurantId(dishId, restaurantId)) {
+            throw new ElementNotFoundException(
+                    String.format(DomainMessagesConstants.DISH_NOT_FOUND_IN_RESTAURANT, dishId, restaurantId));
+        }
+
+        DishModel dishModel = new DishModel();
+        dishModel.setId(dishId);
+        dishModel.setPrice(price);
+        dishModel.setDescription(description);
+        RestaurantModel restaurant = new RestaurantModel();
+        restaurant.setId(restaurantId);
+        dishModel.setRestaurant(restaurant);
+
+        dishValidatorChain.validate(dishModel);
+
         dishPersistencePort.updateDish(dishId, restaurantId, price, description);
     }
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/usecases/RestaurantUseCase.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/usecases/RestaurantUseCase.java
@@ -5,6 +5,7 @@ import com.plazoleta.foodcourtmicroservice.domain.ports.in.RestaurantServicePort
 import com.plazoleta.foodcourtmicroservice.domain.ports.out.RestaurantPersistencePort;
 import com.plazoleta.foodcourtmicroservice.domain.utils.constants.DomainMessagesConstants;
 import com.plazoleta.foodcourtmicroservice.domain.validation.restaurant.RestaurantValidatorChain;
+import com.plazoleta.foodcourtmicroservice.domain.enums.OperationType;
 import com.plazoleta.foodcourtmicroservice.domain.exceptions.ElementAlreadyExistsException;
 
 public class RestaurantUseCase implements RestaurantServicePort {
@@ -20,7 +21,7 @@ public class RestaurantUseCase implements RestaurantServicePort {
 
     @Override
     public void save(RestaurantModel restaurantModel) {
-        restaurantValidatorChain.validate(restaurantModel);
+        restaurantValidatorChain.validate(restaurantModel, OperationType.CREATE);
 
         boolean exists = restaurantPersistencePort.existsByNit(restaurantModel.getNit());
         if (exists) {

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/utils/constants/DomainMessagesConstants.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/utils/constants/DomainMessagesConstants.java
@@ -31,6 +31,7 @@ public final class DomainMessagesConstants {
     public static final String DISH_RESTAURANT_ID_REQUIRED = "Restaurant ID is required.";
 
     public static final String DISH_ALREADY_EXISTS = "A dish with the same name '%s' already exists in this restaurant.";
+    public static final String DISH_NOT_FOUND_IN_RESTAURANT = "Dish with id %d does not belong to restaurant with id %d or does not exist.";
     public static final String DISH_IMAGE_URL_INVALID = "Dish image URL is invalid.";
     public static final String URL_IMAGE_REGEX = "^(https?://).+\\.(jpg|jpeg|png|gif|bmp)$";
 

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/AbstractValidator.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/AbstractValidator.java
@@ -1,5 +1,7 @@
 package com.plazoleta.foodcourtmicroservice.domain.validation;
 
+import com.plazoleta.foodcourtmicroservice.domain.enums.OperationType;
+
 public abstract class AbstractValidator<T> implements Validator<T> {
     private Validator<T> next;
 
@@ -9,12 +11,12 @@ public abstract class AbstractValidator<T> implements Validator<T> {
     }
 
     @Override
-    public void validate(T model) {
-        validateCurrent(model);
+    public void validate(T model, OperationType operationType) {
+        validateCurrent(model, operationType);
         if (next != null) {
-            next.validate(model);
+            next.validate(model, operationType);
         }
     }
 
-    protected abstract void validateCurrent(T model);
+    protected abstract void validateCurrent(T model, OperationType operationType);
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/Validator.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/Validator.java
@@ -1,6 +1,8 @@
 package com.plazoleta.foodcourtmicroservice.domain.validation;
 
+import com.plazoleta.foodcourtmicroservice.domain.enums.OperationType;
+
 public interface Validator<T> {
-    void validate(T model);
+    void validate(T model, OperationType operationType);
     void setNext(Validator<T> next);
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/DishValidatorChain.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/DishValidatorChain.java
@@ -6,6 +6,8 @@ import com.plazoleta.foodcourtmicroservice.domain.validation.dish.impl.DishNameV
 import com.plazoleta.foodcourtmicroservice.domain.validation.dish.impl.DishPriceValidator;
 import com.plazoleta.foodcourtmicroservice.domain.validation.dish.impl.DishRequiredFieldsValidator;
 
+import com.plazoleta.foodcourtmicroservice.domain.enums.OperationType;
+
 public class DishValidatorChain {
     private final Validator<DishModel> chain;
 
@@ -20,7 +22,7 @@ public class DishValidatorChain {
         this.chain = required;
     }
 
-    public void validate(DishModel model) {
-        chain.validate(model);
+    public void validate(DishModel model, OperationType operationType) {
+        chain.validate(model, operationType);
     }
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishImageUrlValidator.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishImageUrlValidator.java
@@ -2,6 +2,7 @@ package com.plazoleta.foodcourtmicroservice.domain.validation.dish.impl;
 
 import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
 import com.plazoleta.foodcourtmicroservice.domain.validation.AbstractValidator;
+import com.plazoleta.foodcourtmicroservice.domain.enums.OperationType;
 import com.plazoleta.foodcourtmicroservice.domain.exceptions.InvalidElementFormatException;
 import com.plazoleta.foodcourtmicroservice.domain.utils.constants.DomainMessagesConstants;
 
@@ -14,7 +15,7 @@ public class DishImageUrlValidator extends AbstractValidator<DishModel> {
             Pattern.CASE_INSENSITIVE);
 
     @Override
-    protected void validateCurrent(DishModel dishModel) {
+    protected void validateCurrent(DishModel dishModel, OperationType operationType) {
         String imageUrl = dishModel.getUrlImage();
         if (imageUrl != null && !imageUrl.trim().isEmpty() && !IMAGE_URL_PATTERN.matcher(imageUrl).matches()) {
             throw new InvalidElementFormatException(DomainMessagesConstants.DISH_IMAGE_URL_INVALID);

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishNameValidator.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishNameValidator.java
@@ -1,15 +1,16 @@
 package com.plazoleta.foodcourtmicroservice.domain.validation.dish.impl;
 
-import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
-import com.plazoleta.foodcourtmicroservice.domain.validation.AbstractValidator;
 import com.plazoleta.foodcourtmicroservice.domain.enums.OperationType;
+import com.plazoleta.foodcourtmicroservice.domain.exceptions.InvalidElementFormatException;
+import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
 import com.plazoleta.foodcourtmicroservice.domain.utils.constants.DomainMessagesConstants;
+import com.plazoleta.foodcourtmicroservice.domain.validation.AbstractValidator;
 
 public class DishNameValidator extends AbstractValidator<DishModel> {
     @Override
     protected void validateCurrent(DishModel dish, OperationType operationType) {
         if (operationType == OperationType.CREATE && dish.getName() != null && dish.getName().trim().isEmpty()) {
-            throw new IllegalArgumentException(DomainMessagesConstants.DISH_NAME_NOT_EMPTY);
+            throw new InvalidElementFormatException(DomainMessagesConstants.DISH_NAME_NOT_EMPTY);
         }
     }
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishNameValidator.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishNameValidator.java
@@ -3,12 +3,13 @@ package com.plazoleta.foodcourtmicroservice.domain.validation.dish.impl;
 import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
 import com.plazoleta.foodcourtmicroservice.domain.validation.AbstractValidator;
 import com.plazoleta.foodcourtmicroservice.domain.enums.OperationType;
+import com.plazoleta.foodcourtmicroservice.domain.utils.constants.DomainMessagesConstants;
 
 public class DishNameValidator extends AbstractValidator<DishModel> {
     @Override
     protected void validateCurrent(DishModel dish, OperationType operationType) {
         if (operationType == OperationType.CREATE && dish.getName() != null && dish.getName().trim().isEmpty()) {
-            throw new IllegalArgumentException("Dish name cannot be empty");
+            throw new IllegalArgumentException(DomainMessagesConstants.DISH_NAME_NOT_EMPTY);
         }
     }
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishNameValidator.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishNameValidator.java
@@ -2,14 +2,13 @@ package com.plazoleta.foodcourtmicroservice.domain.validation.dish.impl;
 
 import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
 import com.plazoleta.foodcourtmicroservice.domain.validation.AbstractValidator;
-import com.plazoleta.foodcourtmicroservice.domain.exceptions.InvalidElementFormatException;
-import com.plazoleta.foodcourtmicroservice.domain.utils.constants.DomainMessagesConstants;
+import com.plazoleta.foodcourtmicroservice.domain.enums.OperationType;
 
 public class DishNameValidator extends AbstractValidator<DishModel> {
     @Override
-    protected void validateCurrent(DishModel dish) {
-        if (dish.getName() != null && dish.getName().trim().isEmpty()) {
-            throw new InvalidElementFormatException(DomainMessagesConstants.DISH_NAME_NOT_EMPTY);
+    protected void validateCurrent(DishModel dish, OperationType operationType) {
+        if (operationType == OperationType.CREATE && dish.getName() != null && dish.getName().trim().isEmpty()) {
+            throw new IllegalArgumentException("Dish name cannot be empty");
         }
     }
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishPriceValidator.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishPriceValidator.java
@@ -1,7 +1,8 @@
 package com.plazoleta.foodcourtmicroservice.domain.validation.dish.impl;
 
-import com.plazoleta.foodcourtmicroservice.domain.utils.constants.DomainMessagesConstants;
+import com.plazoleta.foodcourtmicroservice.domain.exceptions.InvalidElementFormatException;
 import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
+import com.plazoleta.foodcourtmicroservice.domain.utils.constants.DomainMessagesConstants;
 import com.plazoleta.foodcourtmicroservice.domain.validation.AbstractValidator;
 
 
@@ -10,10 +11,10 @@ public class DishPriceValidator extends AbstractValidator<DishModel> {
     protected void validateCurrent(DishModel dish, com.plazoleta.foodcourtmicroservice.domain.enums.OperationType operationType) {
         if (dish.getPrice() != null) {
             if (dish.getPrice().compareTo(java.math.BigDecimal.ZERO) <= 0) {
-                throw new IllegalArgumentException(DomainMessagesConstants.DISH_PRICE_GREATER_THAN_ZERO);
+                throw new InvalidElementFormatException(DomainMessagesConstants.DISH_PRICE_GREATER_THAN_ZERO);
             }
             if (dish.getPrice().stripTrailingZeros().scale() > 0) {
-                throw new IllegalArgumentException(DomainMessagesConstants.DISH_PRICE_MUST_BE_INTEGER);
+                throw new InvalidElementFormatException(DomainMessagesConstants.DISH_PRICE_MUST_BE_INTEGER);
             }
         }
     }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishPriceValidator.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishPriceValidator.java
@@ -2,22 +2,17 @@ package com.plazoleta.foodcourtmicroservice.domain.validation.dish.impl;
 
 import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
 import com.plazoleta.foodcourtmicroservice.domain.validation.AbstractValidator;
-import com.plazoleta.foodcourtmicroservice.domain.exceptions.InvalidElementFormatException;
-import com.plazoleta.foodcourtmicroservice.domain.utils.constants.DomainMessagesConstants;
 
-import java.math.BigDecimal;
 
 public class DishPriceValidator extends AbstractValidator<DishModel> {
     @Override
-    protected void validateCurrent(DishModel dish) {
+    protected void validateCurrent(DishModel dish, com.plazoleta.foodcourtmicroservice.domain.enums.OperationType operationType) {
         if (dish.getPrice() != null) {
-            
-            if (dish.getPrice().compareTo(BigDecimal.ZERO) <= 0) {
-                throw new InvalidElementFormatException(DomainMessagesConstants.DISH_PRICE_GREATER_THAN_ZERO);
+            if (dish.getPrice().compareTo(java.math.BigDecimal.ZERO) <= 0) {
+                throw new IllegalArgumentException("Dish price must be greater than 0");
             }
-
             if (dish.getPrice().stripTrailingZeros().scale() > 0) {
-                throw new InvalidElementFormatException(DomainMessagesConstants.DISH_PRICE_MUST_BE_INTEGER);
+                throw new IllegalArgumentException("Dish price must be an integer");
             }
         }
     }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishPriceValidator.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishPriceValidator.java
@@ -1,5 +1,6 @@
 package com.plazoleta.foodcourtmicroservice.domain.validation.dish.impl;
 
+import com.plazoleta.foodcourtmicroservice.domain.utils.constants.DomainMessagesConstants;
 import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
 import com.plazoleta.foodcourtmicroservice.domain.validation.AbstractValidator;
 
@@ -9,10 +10,10 @@ public class DishPriceValidator extends AbstractValidator<DishModel> {
     protected void validateCurrent(DishModel dish, com.plazoleta.foodcourtmicroservice.domain.enums.OperationType operationType) {
         if (dish.getPrice() != null) {
             if (dish.getPrice().compareTo(java.math.BigDecimal.ZERO) <= 0) {
-                throw new IllegalArgumentException("Dish price must be greater than 0");
+                throw new IllegalArgumentException(DomainMessagesConstants.DISH_PRICE_GREATER_THAN_ZERO);
             }
             if (dish.getPrice().stripTrailingZeros().scale() > 0) {
-                throw new IllegalArgumentException("Dish price must be an integer");
+                throw new IllegalArgumentException(DomainMessagesConstants.DISH_PRICE_MUST_BE_INTEGER);
             }
         }
     }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishRequiredFieldsValidator.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishRequiredFieldsValidator.java
@@ -3,6 +3,7 @@ package com.plazoleta.foodcourtmicroservice.domain.validation.dish.impl;
 import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
 import com.plazoleta.foodcourtmicroservice.domain.validation.AbstractValidator;
 import com.plazoleta.foodcourtmicroservice.domain.enums.OperationType;
+import com.plazoleta.foodcourtmicroservice.domain.utils.constants.DomainMessagesConstants;
 
 public class DishRequiredFieldsValidator extends AbstractValidator<DishModel> {
     @Override
@@ -16,28 +17,28 @@ public class DishRequiredFieldsValidator extends AbstractValidator<DishModel> {
 
     private void validateCreateFields(DishModel dish) {
         if (dish.getName() == null || dish.getName().trim().isEmpty()) {
-            throw new IllegalArgumentException("Dish name cannot be empty");
+            throw new IllegalArgumentException(DomainMessagesConstants.DISH_NAME_NOT_EMPTY);
         }
         if (dish.getDescription() == null || dish.getDescription().trim().isEmpty()) {
-            throw new IllegalArgumentException("Dish description cannot be empty");
+            throw new IllegalArgumentException(DomainMessagesConstants.DISH_DESCRIPTION_REQUIRED);
         }
         if (dish.getRestaurant() == null || dish.getRestaurant().getId() == null) {
-            throw new IllegalArgumentException("Restaurant ID is required");
+            throw new IllegalArgumentException(DomainMessagesConstants.DISH_RESTAURANT_ID_REQUIRED);
         }
         if (dish.getCategoryId() == null) {
-            throw new IllegalArgumentException("Category ID is required");
+            throw new IllegalArgumentException(DomainMessagesConstants.DISH_CATEGORY_ID_REQUIRED);
         }
         if (dish.getPrice() == null) {
-            throw new IllegalArgumentException("Dish price is required");
+            throw new IllegalArgumentException(DomainMessagesConstants.DISH_PRICE_REQUIRED);
         }
     }
 
     private void validateUpdateFields(DishModel dish) {
         if (dish.getPrice() == null) {
-            throw new IllegalArgumentException("Dish price is required");
+            throw new IllegalArgumentException(DomainMessagesConstants.DISH_PRICE_REQUIRED);
         }
         if (dish.getDescription() == null || dish.getDescription().trim().isEmpty()) {
-            throw new IllegalArgumentException("Dish description cannot be empty");
+            throw new IllegalArgumentException(DomainMessagesConstants.DISH_DESCRIPTION_REQUIRED);
         }
     }
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishRequiredFieldsValidator.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishRequiredFieldsValidator.java
@@ -2,26 +2,42 @@ package com.plazoleta.foodcourtmicroservice.domain.validation.dish.impl;
 
 import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
 import com.plazoleta.foodcourtmicroservice.domain.validation.AbstractValidator;
-import com.plazoleta.foodcourtmicroservice.domain.exceptions.RequiredFieldsException;
-import com.plazoleta.foodcourtmicroservice.domain.utils.constants.DomainMessagesConstants;
+import com.plazoleta.foodcourtmicroservice.domain.enums.OperationType;
 
 public class DishRequiredFieldsValidator extends AbstractValidator<DishModel> {
     @Override
-    protected void validateCurrent(DishModel dish) {
-        if (dish.getName() == null) {
-            throw new RequiredFieldsException(DomainMessagesConstants.DISH_NAME_REQUIRED);
+    protected void validateCurrent(DishModel dish, OperationType operationType) {
+        if (operationType == OperationType.CREATE) {
+            validateCreateFields(dish);
+        } else if (operationType == OperationType.UPDATE) {
+            validateUpdateFields(dish);
+        }
+    }
+
+    private void validateCreateFields(DishModel dish) {
+        if (dish.getName() == null || dish.getName().trim().isEmpty()) {
+            throw new IllegalArgumentException("Dish name cannot be empty");
         }
         if (dish.getDescription() == null || dish.getDescription().trim().isEmpty()) {
-            throw new RequiredFieldsException(DomainMessagesConstants.DISH_DESCRIPTION_REQUIRED);
+            throw new IllegalArgumentException("Dish description cannot be empty");
         }
         if (dish.getRestaurant() == null || dish.getRestaurant().getId() == null) {
-            throw new RequiredFieldsException(DomainMessagesConstants.DISH_RESTAURANT_ID_REQUIRED);
+            throw new IllegalArgumentException("Restaurant ID is required");
         }
         if (dish.getCategoryId() == null) {
-            throw new RequiredFieldsException(DomainMessagesConstants.DISH_CATEGORY_ID_REQUIRED);
+            throw new IllegalArgumentException("Category ID is required");
         }
         if (dish.getPrice() == null) {
-            throw new RequiredFieldsException(DomainMessagesConstants.DISH_PRICE_REQUIRED);
+            throw new IllegalArgumentException("Dish price is required");
+        }
+    }
+
+    private void validateUpdateFields(DishModel dish) {
+        if (dish.getPrice() == null) {
+            throw new IllegalArgumentException("Dish price is required");
+        }
+        if (dish.getDescription() == null || dish.getDescription().trim().isEmpty()) {
+            throw new IllegalArgumentException("Dish description cannot be empty");
         }
     }
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishRequiredFieldsValidator.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishRequiredFieldsValidator.java
@@ -1,9 +1,10 @@
 package com.plazoleta.foodcourtmicroservice.domain.validation.dish.impl;
 
-import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
-import com.plazoleta.foodcourtmicroservice.domain.validation.AbstractValidator;
 import com.plazoleta.foodcourtmicroservice.domain.enums.OperationType;
+import com.plazoleta.foodcourtmicroservice.domain.exceptions.RequiredFieldsException;
+import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
 import com.plazoleta.foodcourtmicroservice.domain.utils.constants.DomainMessagesConstants;
+import com.plazoleta.foodcourtmicroservice.domain.validation.AbstractValidator;
 
 public class DishRequiredFieldsValidator extends AbstractValidator<DishModel> {
     @Override
@@ -16,29 +17,29 @@ public class DishRequiredFieldsValidator extends AbstractValidator<DishModel> {
     }
 
     private void validateCreateFields(DishModel dish) {
-        if (dish.getName() == null || dish.getName().trim().isEmpty()) {
-            throw new IllegalArgumentException(DomainMessagesConstants.DISH_NAME_NOT_EMPTY);
+        if (dish.getName() == null) {
+            throw new RequiredFieldsException(DomainMessagesConstants.DISH_NAME_NOT_EMPTY);
         }
         if (dish.getDescription() == null || dish.getDescription().trim().isEmpty()) {
-            throw new IllegalArgumentException(DomainMessagesConstants.DISH_DESCRIPTION_REQUIRED);
+            throw new RequiredFieldsException(DomainMessagesConstants.DISH_DESCRIPTION_REQUIRED);
         }
         if (dish.getRestaurant() == null || dish.getRestaurant().getId() == null) {
-            throw new IllegalArgumentException(DomainMessagesConstants.DISH_RESTAURANT_ID_REQUIRED);
+            throw new RequiredFieldsException(DomainMessagesConstants.DISH_RESTAURANT_ID_REQUIRED);
         }
         if (dish.getCategoryId() == null) {
-            throw new IllegalArgumentException(DomainMessagesConstants.DISH_CATEGORY_ID_REQUIRED);
+            throw new RequiredFieldsException(DomainMessagesConstants.DISH_CATEGORY_ID_REQUIRED);
         }
         if (dish.getPrice() == null) {
-            throw new IllegalArgumentException(DomainMessagesConstants.DISH_PRICE_REQUIRED);
+            throw new RequiredFieldsException(DomainMessagesConstants.DISH_PRICE_REQUIRED);
         }
     }
 
     private void validateUpdateFields(DishModel dish) {
         if (dish.getPrice() == null) {
-            throw new IllegalArgumentException(DomainMessagesConstants.DISH_PRICE_REQUIRED);
+            throw new RequiredFieldsException(DomainMessagesConstants.DISH_PRICE_REQUIRED);
         }
         if (dish.getDescription() == null || dish.getDescription().trim().isEmpty()) {
-            throw new IllegalArgumentException(DomainMessagesConstants.DISH_DESCRIPTION_REQUIRED);
+            throw new RequiredFieldsException(DomainMessagesConstants.DISH_DESCRIPTION_REQUIRED);
         }
     }
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/restaurant/RestaurantValidatorChain.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/restaurant/RestaurantValidatorChain.java
@@ -1,11 +1,13 @@
 package com.plazoleta.foodcourtmicroservice.domain.validation.restaurant;
 
 import com.plazoleta.foodcourtmicroservice.domain.model.RestaurantModel;
+
 import com.plazoleta.foodcourtmicroservice.domain.validation.Validator;
 import com.plazoleta.foodcourtmicroservice.domain.validation.restaurant.impl.RestaurantNameValidator;
 import com.plazoleta.foodcourtmicroservice.domain.validation.restaurant.impl.RestaurantNitValidator;
 import com.plazoleta.foodcourtmicroservice.domain.validation.restaurant.impl.RestaurantPhoneValidator;
 import com.plazoleta.foodcourtmicroservice.domain.validation.restaurant.impl.RestaurantRequiredFieldsValidator;
+import com.plazoleta.foodcourtmicroservice.domain.enums.OperationType;
 
 public class RestaurantValidatorChain {
     private final Validator<RestaurantModel> chain;
@@ -23,7 +25,7 @@ public class RestaurantValidatorChain {
         this.chain = required;
     }
 
-    public void validate(RestaurantModel model) {
-        chain.validate(model);
+    public void validate(RestaurantModel model, OperationType operationType) {
+        chain.validate(model, operationType);
     }
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/restaurant/impl/RestaurantNameValidator.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/restaurant/impl/RestaurantNameValidator.java
@@ -5,16 +5,19 @@ import com.plazoleta.foodcourtmicroservice.domain.model.RestaurantModel;
 import com.plazoleta.foodcourtmicroservice.domain.exceptions.InvalidElementFormatException;
 import com.plazoleta.foodcourtmicroservice.domain.utils.constants.DomainMessagesConstants;
 import com.plazoleta.foodcourtmicroservice.domain.validation.AbstractValidator;
+import com.plazoleta.foodcourtmicroservice.domain.enums.OperationType;
 
 public class RestaurantNameValidator extends AbstractValidator<RestaurantModel> {
     @Override
-    protected void validateCurrent(RestaurantModel model) {
-        String name = model.getName();
-        if (name == null || name.trim().isEmpty()) {
-            throw new InvalidElementFormatException(DomainMessagesConstants.RESTAURANT_NAME_REQUIRED);
-        }
-        if (name.matches(DomainMessagesConstants.NAME_ONLY_NUMBERS_REGEX)) {
-            throw new InvalidElementFormatException(DomainMessagesConstants.RESTAURANT_NAME_NUMERIC);
+    protected void validateCurrent(RestaurantModel model, OperationType operationType) {
+        if (operationType == OperationType.CREATE) {
+            String name = model.getName();
+            if (name == null || name.trim().isEmpty()) {
+                throw new InvalidElementFormatException(DomainMessagesConstants.RESTAURANT_NAME_REQUIRED);
+            }
+            if (name.matches(DomainMessagesConstants.NAME_ONLY_NUMBERS_REGEX)) {
+                throw new InvalidElementFormatException(DomainMessagesConstants.RESTAURANT_NAME_NUMERIC);
+            }
         }
     }
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/restaurant/impl/RestaurantNitValidator.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/restaurant/impl/RestaurantNitValidator.java
@@ -5,16 +5,19 @@ import com.plazoleta.foodcourtmicroservice.domain.model.RestaurantModel;
 import com.plazoleta.foodcourtmicroservice.domain.exceptions.InvalidElementFormatException;
 import com.plazoleta.foodcourtmicroservice.domain.utils.constants.DomainMessagesConstants;
 import com.plazoleta.foodcourtmicroservice.domain.validation.AbstractValidator;
+import com.plazoleta.foodcourtmicroservice.domain.enums.OperationType;
 
 public class RestaurantNitValidator extends AbstractValidator<RestaurantModel> {
     @Override
-    protected void validateCurrent(RestaurantModel model) {
-        String nit = model.getNit();
-        if (nit == null || nit.trim().isEmpty()) {
-            throw new InvalidElementFormatException(DomainMessagesConstants.NIT_REQUIRED);
-        }
-        if (!nit.matches(DomainMessagesConstants.NIT_NUMERIC_REGEX)) {
-            throw new InvalidElementFormatException(DomainMessagesConstants.NIT_NUMERIC);
+    protected void validateCurrent(RestaurantModel model, OperationType operationType) {
+        if (operationType == OperationType.CREATE) {
+            String nit = model.getNit();
+            if (nit == null || nit.trim().isEmpty()) {
+                throw new InvalidElementFormatException(DomainMessagesConstants.NIT_REQUIRED);
+            }
+            if (!nit.matches(DomainMessagesConstants.NIT_NUMERIC_REGEX)) {
+                throw new InvalidElementFormatException(DomainMessagesConstants.NIT_NUMERIC);
+            }
         }
     }
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/restaurant/impl/RestaurantPhoneValidator.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/restaurant/impl/RestaurantPhoneValidator.java
@@ -1,24 +1,27 @@
 package com.plazoleta.foodcourtmicroservice.domain.validation.restaurant.impl;
 
-
 import com.plazoleta.foodcourtmicroservice.domain.model.RestaurantModel;
 import com.plazoleta.foodcourtmicroservice.domain.exceptions.InvalidElementFormatException;
 import com.plazoleta.foodcourtmicroservice.domain.exceptions.InvalidElementLengthException;
 import com.plazoleta.foodcourtmicroservice.domain.utils.constants.DomainMessagesConstants;
 import com.plazoleta.foodcourtmicroservice.domain.validation.AbstractValidator;
+import com.plazoleta.foodcourtmicroservice.domain.enums.OperationType;
 
 public class RestaurantPhoneValidator extends AbstractValidator<RestaurantModel> {
     @Override
-    protected void validateCurrent(RestaurantModel model) {
-        String phone = model.getPhoneNumber();
-        if (phone == null || phone.trim().isEmpty()) {
-            throw new InvalidElementFormatException(DomainMessagesConstants.PHONE_REQUIRED);
-        }
-        if (phone.length() > DomainMessagesConstants.PHONE_MAX_LENGTH) {
-            throw new InvalidElementLengthException(String.format(DomainMessagesConstants.PHONE_LENGTH, DomainMessagesConstants.PHONE_MAX_LENGTH));
-        }
-        if (!phone.matches(DomainMessagesConstants.PHONE_REGEX)) {
-            throw new InvalidElementFormatException(DomainMessagesConstants.PHONE_FORMAT);
+    protected void validateCurrent(RestaurantModel model, OperationType operationType) {
+        if (operationType == OperationType.CREATE) {
+            String phone = model.getPhoneNumber();
+            if (phone == null || phone.trim().isEmpty()) {
+                throw new InvalidElementFormatException(DomainMessagesConstants.PHONE_REQUIRED);
+            }
+            if (phone.length() > DomainMessagesConstants.PHONE_MAX_LENGTH) {
+                throw new InvalidElementLengthException(
+                        String.format(DomainMessagesConstants.PHONE_LENGTH, DomainMessagesConstants.PHONE_MAX_LENGTH));
+            }
+            if (!phone.matches(DomainMessagesConstants.PHONE_REGEX)) {
+                throw new InvalidElementFormatException(DomainMessagesConstants.PHONE_FORMAT);
+            }
         }
     }
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/restaurant/impl/RestaurantRequiredFieldsValidator.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/restaurant/impl/RestaurantRequiredFieldsValidator.java
@@ -4,17 +4,19 @@ import com.plazoleta.foodcourtmicroservice.domain.model.RestaurantModel;
 import com.plazoleta.foodcourtmicroservice.domain.exceptions.RequiredFieldsException;
 import com.plazoleta.foodcourtmicroservice.domain.utils.constants.DomainMessagesConstants;
 import com.plazoleta.foodcourtmicroservice.domain.validation.AbstractValidator;
+import com.plazoleta.foodcourtmicroservice.domain.enums.OperationType;
 
 public class RestaurantRequiredFieldsValidator extends AbstractValidator<RestaurantModel> {
     
     @Override
-    protected void validateCurrent(RestaurantModel model) {
-        if (model.getName() == null || model.getName().trim().isEmpty() ||
-                model.getNit() == null || model.getNit().trim().isEmpty() ||
-                model.getAddress() == null || model.getAddress().trim().isEmpty() ||
-                model.getPhoneNumber() == null || model.getPhoneNumber().trim().isEmpty() ||
-                model.getUrlLogo() == null || model.getUrlLogo().trim().isEmpty()) {
-            throw new RequiredFieldsException(DomainMessagesConstants.REQUIRED_FIELDS);
-        }
+    protected void validateCurrent(RestaurantModel model, OperationType operationType) {
+        if (operationType == OperationType.CREATE && (model.getName() == null || model.getName().trim().isEmpty() ||
+                    model.getNit() == null || model.getNit().trim().isEmpty() ||
+                    model.getAddress() == null || model.getAddress().trim().isEmpty() ||
+                    model.getPhoneNumber() == null || model.getPhoneNumber().trim().isEmpty() ||
+                    model.getUrlLogo() == null || model.getUrlLogo().trim().isEmpty())) {
+                throw new RequiredFieldsException(DomainMessagesConstants.REQUIRED_FIELDS);
+            }
+        
     }
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/adapters/persistence/DishPersistenceAdapter.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/adapters/persistence/DishPersistenceAdapter.java
@@ -1,6 +1,5 @@
 package com.plazoleta.foodcourtmicroservice.infrastructure.adapters.persistence;
 
-
 import java.math.BigDecimal;
 
 import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
@@ -35,5 +34,12 @@ public class DishPersistenceAdapter implements DishPersistencePort {
             dish.setDescription(description);
             dishRepository.save(dish);
         });
+    }
+
+    @Override
+    public boolean existsByIdAndRestaurantId(Long dishId, Long restaurantId) {
+        return dishRepository.count(
+            DishSpecifications.idEqualsAndRestaurantId(dishId, restaurantId)
+        ) > 0;
     }
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/adapters/persistence/DishPersistenceAdapter.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/adapters/persistence/DishPersistenceAdapter.java
@@ -1,6 +1,8 @@
 package com.plazoleta.foodcourtmicroservice.infrastructure.adapters.persistence;
 
 
+import java.math.BigDecimal;
+
 import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
 import com.plazoleta.foodcourtmicroservice.domain.ports.out.DishPersistencePort;
 import com.plazoleta.foodcourtmicroservice.infrastructure.mappers.DishEntityMapper;
@@ -24,5 +26,14 @@ public class DishPersistenceAdapter implements DishPersistencePort {
     public boolean existsByNameAndRestaurantId(String name, Long restaurantId) {
         return dishRepository.count(
                 DishSpecifications.nameEqualsIgnoreCaseAndRestaurantId(name, restaurantId)) > 0;
+    }
+
+    @Override
+    public void updateDish(Long dishId, Long restaurantId, BigDecimal price, String description) {
+        dishRepository.findById(dishId).ifPresent(dish -> {
+            dish.setPrice(price);
+            dish.setDescription(description);
+            dishRepository.save(dish);
+        });
     }
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/controllers/rest/DishController.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/controllers/rest/DishController.java
@@ -1,7 +1,5 @@
 package com.plazoleta.foodcourtmicroservice.infrastructure.controllers.rest;
 
-// ...existing code...
-
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -16,7 +14,6 @@ import com.plazoleta.foodcourtmicroservice.application.dto.request.UpdateDishReq
 import com.plazoleta.foodcourtmicroservice.application.dto.response.SaveDishResponse;
 import com.plazoleta.foodcourtmicroservice.application.dto.response.UpdateDishResponse;
 import com.plazoleta.foodcourtmicroservice.application.handler.DishHandler;
-// ...existing code...
 import com.plazoleta.foodcourtmicroservice.infrastructure.exceptionhandler.ExceptionResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -47,8 +44,17 @@ public class DishController {
                 return ResponseEntity.status(HttpStatus.CREATED).body(dishHandler.save(request));
         }
 
+        @Operation(summary = "Update a dish", description = "Updates the price and/or description of a dish for a given restaurant.")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "200", description = "Dish updated successfully", content = @Content(schema = @Schema(implementation = UpdateDishResponse.class))),
+                        @ApiResponse(responseCode = "400", description = "Invalid input data", content = @Content(schema = @Schema(implementation = ExceptionResponse.class))),
+                        @ApiResponse(responseCode = "404", description = "Dish not found", content = @Content(schema = @Schema(implementation = ExceptionResponse.class))),
+                        @ApiResponse(responseCode = "500", description = "Internal server error", content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
+        })
         @PatchMapping("/{dishId}")
-        public ResponseEntity<UpdateDishResponse> update(@PathVariable Long dishId, @RequestBody UpdateDishRequest request) {
+        public ResponseEntity<UpdateDishResponse> update(
+                        @PathVariable @Schema(description = "ID of the dish to update", example = "1") Long dishId,
+                        @RequestBody UpdateDishRequest request) {
                 return ResponseEntity.status(HttpStatus.OK).body(dishHandler.update(dishId, request));
         }
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/controllers/rest/DishController.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/controllers/rest/DishController.java
@@ -1,15 +1,22 @@
 package com.plazoleta.foodcourtmicroservice.infrastructure.controllers.rest;
 
+// ...existing code...
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.plazoleta.foodcourtmicroservice.application.dto.request.SaveDishRequest;
+import com.plazoleta.foodcourtmicroservice.application.dto.request.UpdateDishRequest;
 import com.plazoleta.foodcourtmicroservice.application.dto.response.SaveDishResponse;
+import com.plazoleta.foodcourtmicroservice.application.dto.response.UpdateDishResponse;
 import com.plazoleta.foodcourtmicroservice.application.handler.DishHandler;
+// ...existing code...
 import com.plazoleta.foodcourtmicroservice.infrastructure.exceptionhandler.ExceptionResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -26,17 +33,22 @@ import lombok.RequiredArgsConstructor;
 @Tag(name = "Dish", description = "Operations related to dishes")
 public class DishController {
 
-    private final DishHandler dishHandler;
+        private final DishHandler dishHandler;
 
-    @Operation(summary = "Create a new dish", description = "Creates a new dish with the provided data.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "Dish created successfully", content = @Content(schema = @Schema(implementation = SaveDishResponse.class))),
-            @ApiResponse(responseCode = "400", description = "Invalid input data", content = @Content(schema = @Schema(implementation = ExceptionResponse.class))),
-            @ApiResponse(responseCode = "409", description = "Dish with given name already exists in this restaurant", content = @Content(schema = @Schema(implementation = ExceptionResponse.class))),
-            @ApiResponse(responseCode = "500", description = "Internal server error", content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
-    })
-    @PostMapping
-    public ResponseEntity<SaveDishResponse> save(@RequestBody SaveDishRequest request) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(dishHandler.save(request));
-    }
+        @Operation(summary = "Create a new dish", description = "Creates a new dish with the provided data.")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "201", description = "Dish created successfully", content = @Content(schema = @Schema(implementation = SaveDishResponse.class))),
+                        @ApiResponse(responseCode = "400", description = "Invalid input data", content = @Content(schema = @Schema(implementation = ExceptionResponse.class))),
+                        @ApiResponse(responseCode = "409", description = "Dish with given name already exists in this restaurant", content = @Content(schema = @Schema(implementation = ExceptionResponse.class))),
+                        @ApiResponse(responseCode = "500", description = "Internal server error", content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
+        })
+        @PostMapping
+        public ResponseEntity<SaveDishResponse> save(@RequestBody SaveDishRequest request) {
+                return ResponseEntity.status(HttpStatus.CREATED).body(dishHandler.save(request));
+        }
+
+        @PatchMapping("/{dishId}")
+        public ResponseEntity<UpdateDishResponse> update(@PathVariable Long dishId, @RequestBody UpdateDishRequest request) {
+                return ResponseEntity.status(HttpStatus.OK).body(dishHandler.update(dishId, request));
+        }
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/exceptionhandler/ControllerAdvisor.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/exceptionhandler/ControllerAdvisor.java
@@ -38,6 +38,12 @@ public class ControllerAdvisor {
                                 .body(new ExceptionResponse(exception.getMessage(), LocalDateTime.now()));
         }
 
+        @ExceptionHandler(ElementNotFoundException.class)
+        public ResponseEntity<ExceptionResponse> handleElementNotFoundException(ElementNotFoundException exception) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                                .body(new ExceptionResponse(exception.getMessage(), LocalDateTime.now()));
+        }
+
         @ExceptionHandler(Exception.class)
         public ResponseEntity<ExceptionResponse> handleGenericException(Exception exception) {
                 String message = "An unexpected error occurred. Please contact support if the problem persists.";

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/specifications/DishSpecifications.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/specifications/DishSpecifications.java
@@ -11,8 +11,13 @@ public class DishSpecifications {
 
     public static Specification<DishEntity> nameEqualsIgnoreCaseAndRestaurantId(String name, Long restaurantId) {
         return (root, query, cb) -> cb.and(
-            cb.equal(cb.lower(root.get("name")), name.toLowerCase()),
-            cb.equal(root.get("restaurant").get("id"), restaurantId)
-        );
+                cb.equal(cb.lower(root.get("name")), name.toLowerCase()),
+                cb.equal(root.get("restaurant").get("id"), restaurantId));
+    }
+
+    public static Specification<DishEntity> idEqualsAndRestaurantId(Long dishId, Long restaurantId) {
+        return (root, query, cb) -> cb.and(
+                cb.equal(root.get("id"), dishId),
+                cb.equal(root.get("restaurant").get("id"), restaurantId));
     }
 }

--- a/src/test/java/com/plazoleta/foodcourtmicroservice/domain/usecases/RestaurantUseCaseTest.java
+++ b/src/test/java/com/plazoleta/foodcourtmicroservice/domain/usecases/RestaurantUseCaseTest.java
@@ -15,6 +15,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import com.plazoleta.foodcourtmicroservice.domain.enums.OperationType;
 import com.plazoleta.foodcourtmicroservice.domain.exceptions.ElementAlreadyExistsException;
 import com.plazoleta.foodcourtmicroservice.domain.model.RestaurantModel;
 import com.plazoleta.foodcourtmicroservice.domain.ports.out.RestaurantPersistencePort;
@@ -49,7 +50,7 @@ class RestaurantUseCaseTest {
         useCase.save(model);
 
         // Assert
-        verify(validatorChain, times(1)).validate(model);
+        verify(validatorChain, times(1)).validate(model, OperationType.CREATE);
         verify(persistencePort, times(1)).existsByNit(model.getNit());
         verify(persistencePort, times(1)).save(model);
     }
@@ -63,7 +64,7 @@ class RestaurantUseCaseTest {
         ElementAlreadyExistsException ex = assertThrows(ElementAlreadyExistsException.class, () -> useCase.save(model));
         assertEquals(String.format(DomainMessagesConstants.RESTAURANT_NIT_ALREADY_EXISTS, model.getNit()),
                 ex.getMessage());
-        verify(validatorChain, times(1)).validate(model);
+        verify(validatorChain, times(1)).validate(model, OperationType.CREATE);
         verify(persistencePort, times(1)).existsByNit(model.getNit());
         verify(persistencePort, never()).save(any());
     }
@@ -71,12 +72,12 @@ class RestaurantUseCaseTest {
     @Test
     void when_save_withInvalidRestaurant_then_throwValidationException() {
         // Arrange
-        doThrow(new RuntimeException("Validation error")).when(validatorChain).validate(model);
+        doThrow(new RuntimeException("Validation error")).when(validatorChain).validate(model, OperationType.CREATE);
 
         // Act & Assert
         RuntimeException ex = assertThrows(RuntimeException.class, () -> useCase.save(model));
         assertEquals("Validation error", ex.getMessage());
-        verify(validatorChain, times(1)).validate(model);
+        verify(validatorChain, times(1)).validate(model, OperationType.CREATE);
         verify(persistencePort, never()).existsByNit(any());
         verify(persistencePort, never()).save(any());
     }

--- a/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/AbstractValidatorTest.java
+++ b/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/AbstractValidatorTest.java
@@ -1,15 +1,17 @@
 package com.plazoleta.foodcourtmicroservice.domain.validation;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import com.plazoleta.foodcourtmicroservice.domain.enums.OperationType;
 
 class AbstractValidatorTest {
 
     static class DummyValidator extends AbstractValidator<String> {
         boolean validated = false;
         @Override
-        protected void validateCurrent(String model) {
+        protected void validateCurrent(String model, OperationType operationType) {
             validated = true;
         }
     }
@@ -17,7 +19,7 @@ class AbstractValidatorTest {
     @Test
     void when_validate_then_validateCurrentIsCalled() {
         DummyValidator validator = new DummyValidator();
-        validator.validate("test");
+        validator.validate("test", OperationType.CREATE);
         assertTrue(validator.validated, "validateCurrent should be called");
     }
 
@@ -27,7 +29,7 @@ class AbstractValidatorTest {
         DummyValidator second = new DummyValidator();
         first.setNext(second);
 
-        first.validate("test");
+        first.validate("test", OperationType.CREATE);
 
         assertTrue(first.validated, "First validator should be called");
         assertTrue(second.validated, "Second validator should be called");

--- a/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/DishValidatorChainTest.java
+++ b/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/DishValidatorChainTest.java
@@ -1,15 +1,17 @@
 package com.plazoleta.foodcourtmicroservice.domain.validation.dish;
 
-import com.plazoleta.foodcourtmicroservice.domain.model.RestaurantModel;
-
-import com.plazoleta.foodcourtmicroservice.domain.exceptions.InvalidElementFormatException;
-import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.math.BigDecimal;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.Test;
+
+import com.plazoleta.foodcourtmicroservice.domain.enums.OperationType;
+import com.plazoleta.foodcourtmicroservice.domain.exceptions.InvalidElementFormatException;
+import com.plazoleta.foodcourtmicroservice.domain.exceptions.RequiredFieldsException;
+import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
+import com.plazoleta.foodcourtmicroservice.domain.model.RestaurantModel;
 
 class DishValidatorChainTest {
 
@@ -24,26 +26,26 @@ class DishValidatorChainTest {
     void when_allFieldsValid_then_noException() {
         DishModel model = new DishModel(1L, "Pizza", new BigDecimal("10000"), "desc", "https://img.com/pizza.jpg", 2L,
                 buildRestaurant(10L), true);
-        assertDoesNotThrow(() -> validatorChain.validate(model));
+        assertDoesNotThrow(() -> validatorChain.validate(model, OperationType.CREATE));
     }
 
     @Test
-    void when_missingRequiredField_then_throwInvalidElementFormatException() {
-        DishModel model = new DishModel(1L, "", new BigDecimal("10000"), "desc", "url", 2L, buildRestaurant(10L), true);
-        assertThrows(InvalidElementFormatException.class, () -> validatorChain.validate(model));
+    void when_missingRequiredField_then_throwRequiredFieldsException() {
+        DishModel model = new DishModel(1L, "name", new BigDecimal("10000"), " ", "url", 2L, buildRestaurant(10L), true);
+        assertThrows(RequiredFieldsException.class, () -> validatorChain.validate(model, OperationType.CREATE));
     }
 
     @Test
     void when_invalidName_then_throwInvalidElementFormatException() {
         DishModel model = new DishModel(1L, "   ", new BigDecimal("10000"), "desc", "url", 2L, buildRestaurant(10L),
                 true);
-        assertThrows(InvalidElementFormatException.class, () -> validatorChain.validate(model));
+        assertThrows(InvalidElementFormatException.class, () -> validatorChain.validate(model, OperationType.CREATE));
     }
 
     @Test
     void when_invalidPrice_then_throwInvalidElementFormatException() {
         DishModel model = new DishModel(1L, "Pizza", new BigDecimal("0"), "desc", "url", 2L, buildRestaurant(10L),
                 true);
-        assertThrows(InvalidElementFormatException.class, () -> validatorChain.validate(model));
+        assertThrows(InvalidElementFormatException.class, () -> validatorChain.validate(model, OperationType.CREATE));
     }
 }

--- a/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishImageUrlValidatorTest.java
+++ b/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishImageUrlValidatorTest.java
@@ -13,6 +13,8 @@ import com.plazoleta.foodcourtmicroservice.domain.exceptions.InvalidElementForma
 import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
 import com.plazoleta.foodcourtmicroservice.domain.model.RestaurantModel;
 
+import com.plazoleta.foodcourtmicroservice.domain.enums.OperationType;
+
 class DishImageUrlValidatorTest {
 
     private final DishImageUrlValidator validator = new DishImageUrlValidator();
@@ -27,13 +29,13 @@ class DishImageUrlValidatorTest {
     void when_validOrEmptyOrNullImageUrl_then_noException(String imageUrl) {
         DishModel model = new DishModel(1L, "Pizza", new BigDecimal("10000"), "desc", imageUrl, 2L,
                 buildRestaurant(10L), true);
-        assertDoesNotThrow(() -> validator.validate(model));
+        assertDoesNotThrow(() -> validator.validate(model, OperationType.CREATE));
     }
 
     @Test
     void when_invalidImageUrl_then_throwInvalidElementFormatException() {
         DishModel model = new DishModel(1L, "Pizza", new BigDecimal("10000"), "desc", "notaurl", 2L,
                 buildRestaurant(10L), true);
-        assertThrows(InvalidElementFormatException.class, () -> validator.validate(model));
+        assertThrows(InvalidElementFormatException.class, () -> validator.validate(model, OperationType.CREATE));
     }
 }

--- a/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishNameValidatorTest.java
+++ b/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishNameValidatorTest.java
@@ -2,6 +2,8 @@ package com.plazoleta.foodcourtmicroservice.domain.validation.dish.impl;
 
 import com.plazoleta.foodcourtmicroservice.domain.model.RestaurantModel;
 
+import com.plazoleta.foodcourtmicroservice.domain.enums.OperationType;
+
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -22,7 +24,7 @@ class DishNameValidatorTest {
     void when_validName_then_noException() {
         DishModel model = new DishModel(1L, "Pizza", new BigDecimal("10000"), "desc", "url", 2L, buildRestaurant(10L),
                 true);
-        assertDoesNotThrow(() -> validator.validate(model));
+        assertDoesNotThrow(() -> validator.validate(model, OperationType.CREATE));
     }
 
     @org.junit.jupiter.params.ParameterizedTest
@@ -30,13 +32,13 @@ class DishNameValidatorTest {
     void when_invalidName_then_throwInvalidElementFormatException(String invalidName) {
         DishModel model = new DishModel(1L, invalidName, new BigDecimal("10000"), "desc", "url", 2L,
                 buildRestaurant(10L), true);
-        assertThrows(InvalidElementFormatException.class, () -> validator.validate(model));
+        assertThrows(InvalidElementFormatException.class, () -> validator.validate(model, OperationType.CREATE));
     }
 
     @Test
     void when_nullName_then_noException() {
         DishModel model = new DishModel(1L, null, new BigDecimal("10000"), "desc", "url", 2L, buildRestaurant(10L),
                 true);
-        assertDoesNotThrow(() -> validator.validate(model));
+        assertDoesNotThrow(() -> validator.validate(model, OperationType.CREATE));
     }
 }

--- a/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishPriceValidatorTest.java
+++ b/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishPriceValidatorTest.java
@@ -2,6 +2,8 @@ package com.plazoleta.foodcourtmicroservice.domain.validation.dish.impl;
 
 import com.plazoleta.foodcourtmicroservice.domain.model.RestaurantModel;
 
+import com.plazoleta.foodcourtmicroservice.domain.enums.OperationType;
+
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -23,7 +25,7 @@ class DishPriceValidatorTest {
     void when_validPrice_then_noException() {
         DishModel model = new DishModel(1L, "Pizza", new BigDecimal("10000"), "desc", "url", 2L, buildRestaurant(10L),
                 true);
-        assertDoesNotThrow(() -> validator.validate(model));
+        assertDoesNotThrow(() -> validator.validate(model, OperationType.CREATE));
     }
 
     @Test
@@ -32,14 +34,14 @@ class DishPriceValidatorTest {
                 true);
         DishModel negativePrice = new DishModel(1L, "Pizza", new BigDecimal("-1"), "desc", "url", 2L,
                 buildRestaurant(10L), true);
-        assertThrows(InvalidElementFormatException.class, () -> validator.validate(zeroPrice));
-        assertThrows(InvalidElementFormatException.class, () -> validator.validate(negativePrice));
+        assertThrows(InvalidElementFormatException.class, () -> validator.validate(zeroPrice, OperationType.CREATE));
+        assertThrows(InvalidElementFormatException.class, () -> validator.validate(negativePrice, OperationType.CREATE));
     }
 
     @Test
     void when_priceIsNotInteger_then_throwInvalidElementFormatException() {
         DishModel decimalPrice = new DishModel(1L, "Pizza", new BigDecimal("10000.50"), "desc", "url", 2L,
                 buildRestaurant(10L), true);
-        assertThrows(InvalidElementFormatException.class, () -> validator.validate(decimalPrice));
+        assertThrows(InvalidElementFormatException.class, () -> validator.validate(decimalPrice, OperationType.CREATE));
     }
 }

--- a/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishRequiredFieldsValidatorTest.java
+++ b/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishRequiredFieldsValidatorTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import com.plazoleta.foodcourtmicroservice.domain.exceptions.RequiredFieldsException;
 import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
 import com.plazoleta.foodcourtmicroservice.domain.model.RestaurantModel;
+import com.plazoleta.foodcourtmicroservice.domain.enums.OperationType;
 
 class DishRequiredFieldsValidatorTest {
     private final DishRequiredFieldsValidator validator = new DishRequiredFieldsValidator();
@@ -22,48 +23,75 @@ class DishRequiredFieldsValidatorTest {
     @Test
     void when_allFieldsPresent_then_noException() {
         DishModel model = new DishModel(1L, "Hamburguesa", new BigDecimal("15000.00"), "Clásica hamburguesa", "https://img.com/hamburguesa.jpg", 10L, buildRestaurant(2L), true);
-        assertDoesNotThrow(() -> validator.validate(model));
+        assertDoesNotThrow(() -> validator.validate(model, OperationType.CREATE));
     }
 
     @Test
     void when_missingName_then_throwRequiredFieldsException() {
         DishModel model = new DishModel(1L, null, new BigDecimal("15000.00"), "desc", "url", 10L, buildRestaurant(2L), true);
-        assertThrows(RequiredFieldsException.class, () -> validator.validate(model));
+        assertThrows(RequiredFieldsException.class, () -> validator.validate(model, OperationType.CREATE));
     }
 
     @Test
     void when_missingDescription_then_throwRequiredFieldsException() {
         DishModel model = new DishModel(1L, "Hamburguesa", new BigDecimal("15000.00"), null, "url", 10L, buildRestaurant(2L), true);
-        assertThrows(RequiredFieldsException.class, () -> validator.validate(model));
+        assertThrows(RequiredFieldsException.class, () -> validator.validate(model, OperationType.CREATE));
     }
 
     @Test
     void when_descriptionIsEmpty_then_throwRequiredFieldsException() {
         DishModel model = new DishModel(1L, "Hamburguesa", new BigDecimal("15000.00"), "", "url", 10L, buildRestaurant(2L), true);
-        assertThrows(RequiredFieldsException.class, () -> validator.validate(model));
+        assertThrows(RequiredFieldsException.class, () -> validator.validate(model, OperationType.CREATE));
     }
 
     @Test
     void when_descriptionIsBlank_then_throwRequiredFieldsException() {
         DishModel model = new DishModel(1L, "Hamburguesa", new BigDecimal("15000.00"), "   ", "url", 10L, buildRestaurant(2L), true);
-        assertThrows(RequiredFieldsException.class, () -> validator.validate(model));
+        assertThrows(RequiredFieldsException.class, () -> validator.validate(model, OperationType.CREATE));
     }
 
     @Test
     void when_missingRestaurant_then_throwRequiredFieldsException() {
         DishModel model = new DishModel(1L, "Hamburguesa", new BigDecimal("15000.00"), "desc", "url", 10L, null, true);
-        assertThrows(RequiredFieldsException.class, () -> validator.validate(model));
+        assertThrows(RequiredFieldsException.class, () -> validator.validate(model, OperationType.CREATE));
     }
 
     @Test
     void when_missingCategoryId_then_throwRequiredFieldsException() {
         DishModel model = new DishModel(1L, "Hamburguesa", new BigDecimal("15000.00"), "desc", "url", null, buildRestaurant(2L), true);
-        assertThrows(RequiredFieldsException.class, () -> validator.validate(model));
+        assertThrows(RequiredFieldsException.class, () -> validator.validate(model, OperationType.CREATE));
     }
 
     @Test
     void when_missingPrice_then_throwRequiredFieldsException() {
         DishModel model = new DishModel(1L, "Hamburguesa", null, "desc", "url", 10L, buildRestaurant(2L), true);
-        assertThrows(RequiredFieldsException.class, () -> validator.validate(model));
+        assertThrows(RequiredFieldsException.class, () -> validator.validate(model, OperationType.CREATE));
+    }
+
+    // --- UPDATE tests ---
+    @Test
+    void when_update_withAllFieldsPresent_then_noException() {
+        DishModel model = new DishModel();
+        model.setPrice(new BigDecimal("12000.00"));
+        model.setDescription("Nueva descripción");
+        assertDoesNotThrow(() -> validator.validate(model, OperationType.UPDATE));
+    }
+
+    @Test
+    void when_update_missingPrice_then_throwRequiredFieldsException() {
+        DishModel model = new DishModel();
+        model.setDescription("desc");
+        model.setPrice(null);
+        assertThrows(RequiredFieldsException.class, () -> validator.validate(model, OperationType.UPDATE));
+    }
+
+    @org.junit.jupiter.params.ParameterizedTest
+    @org.junit.jupiter.params.provider.NullAndEmptySource
+    @org.junit.jupiter.params.provider.ValueSource(strings = {"   "})
+    void when_update_invalidDescription_then_throwRequiredFieldsException(String description) {
+        DishModel model = new DishModel();
+        model.setPrice(new BigDecimal("12000.00"));
+        model.setDescription(description);
+        assertThrows(RequiredFieldsException.class, () -> validator.validate(model, OperationType.UPDATE));
     }
 }

--- a/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/restaurant/RestaurantValidatorChainTest.java
+++ b/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/restaurant/RestaurantValidatorChainTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
+import com.plazoleta.foodcourtmicroservice.domain.enums.OperationType;
 import com.plazoleta.foodcourtmicroservice.domain.model.RestaurantModel;
 
 class RestaurantValidatorChainTest {
@@ -13,13 +14,13 @@ class RestaurantValidatorChainTest {
     void when_validModel_then_noException() {
         RestaurantModel model = new RestaurantModel(1L, "Pizza Place", "123456789", "Street 1", "+573001234567", "logo.png", 10L);
         RestaurantValidatorChain chain = new RestaurantValidatorChain();
-        assertDoesNotThrow(() -> chain.validate(model));
+        assertDoesNotThrow(() -> chain.validate(model, OperationType.CREATE));
     }
 
     @Test
     void when_invalidModel_then_exceptionThrown() {
         RestaurantModel model = new RestaurantModel(null, null, null, null, null, null, null);
         RestaurantValidatorChain chain = new RestaurantValidatorChain();
-        assertThrows(Exception.class, () -> chain.validate(model));
+        assertThrows(Exception.class, () -> chain.validate(model, OperationType.CREATE));
     }
 }

--- a/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/restaurant/impl/RestaurantNameValidatorTest.java
+++ b/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/restaurant/impl/RestaurantNameValidatorTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
+import com.plazoleta.foodcourtmicroservice.domain.enums.OperationType;
 import com.plazoleta.foodcourtmicroservice.domain.exceptions.InvalidElementFormatException;
 import com.plazoleta.foodcourtmicroservice.domain.model.RestaurantModel;
 
@@ -14,7 +15,7 @@ class RestaurantNameValidatorTest {
     @Test
     void when_validName_then_noException() {
         RestaurantModel model = new RestaurantModel(1L, "Pizza Place", "123456789", "Street 1", "+573001234567", "logo.png", 10L);
-        assertDoesNotThrow(() -> validator.validate(model));
+        assertDoesNotThrow(() -> validator.validate(model, OperationType.CREATE));
     }
 
     @org.junit.jupiter.params.ParameterizedTest
@@ -22,6 +23,6 @@ class RestaurantNameValidatorTest {
     @org.junit.jupiter.params.provider.ValueSource(strings = {"   ", "123456"})
     void when_invalidName_then_throwInvalidElementFormatException(String invalidName) {
         RestaurantModel model = new RestaurantModel(1L, invalidName, "123456789", "Street 1", "+573001234567", "logo.png", 10L);
-        assertThrows(InvalidElementFormatException.class, () -> validator.validate(model));
+        assertThrows(InvalidElementFormatException.class, () -> validator.validate(model, OperationType.CREATE));
     }
 }

--- a/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/restaurant/impl/RestaurantNitValidatorTest.java
+++ b/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/restaurant/impl/RestaurantNitValidatorTest.java
@@ -1,5 +1,7 @@
 package com.plazoleta.foodcourtmicroservice.domain.validation.restaurant.impl;
 
+import com.plazoleta.foodcourtmicroservice.domain.enums.OperationType;
+
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -14,7 +16,7 @@ class RestaurantNitValidatorTest {
     @Test
     void when_validNit_then_noException() {
         RestaurantModel model = new RestaurantModel(1L, "Pizza Place", "123456789", "Street 1", "+573001234567", "logo.png", 10L);
-        assertDoesNotThrow(() -> validator.validate(model));
+        assertDoesNotThrow(() -> validator.validate(model, OperationType.CREATE));
     }
 
     @org.junit.jupiter.params.ParameterizedTest
@@ -22,6 +24,6 @@ class RestaurantNitValidatorTest {
     @org.junit.jupiter.params.provider.ValueSource(strings = {"   ", "ABC123"})
     void when_invalidNit_then_throwInvalidElementFormatException(String nit) {
         RestaurantModel model = new RestaurantModel(1L, "Pizza Place", nit, "Street 1", "+573001234567", "logo.png", 10L);
-        assertThrows(InvalidElementFormatException.class, () -> validator.validate(model));
+        assertThrows(InvalidElementFormatException.class, () -> validator.validate(model, OperationType.CREATE));
     }
 }

--- a/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/restaurant/impl/RestaurantPhoneValidatorTest.java
+++ b/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/restaurant/impl/RestaurantPhoneValidatorTest.java
@@ -1,5 +1,7 @@
 package com.plazoleta.foodcourtmicroservice.domain.validation.restaurant.impl;
 
+import com.plazoleta.foodcourtmicroservice.domain.enums.OperationType;
+
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -19,7 +21,7 @@ class RestaurantPhoneValidatorTest {
     @Test
     void when_validPhone_then_noException() {
         RestaurantModel model = new RestaurantModel(1L, "Pizza Place", "123456789", "Street 1", "+573001234567", "logo.png", 10L);
-        assertDoesNotThrow(() -> validator.validate(model));
+        assertDoesNotThrow(() -> validator.validate(model, OperationType.CREATE));
     }
 
     @ParameterizedTest
@@ -27,13 +29,13 @@ class RestaurantPhoneValidatorTest {
     @ValueSource(strings = {"   "})
     void when_phoneIsNullOrEmpty_then_throwInvalidElementFormatException(String phone) {
         RestaurantModel model = new RestaurantModel(1L, "Pizza Place", "123456789", "Street 1", phone, "logo.png", 10L);
-        assertThrows(InvalidElementFormatException.class, () -> validator.validate(model));
+        assertThrows(InvalidElementFormatException.class, () -> validator.validate(model, OperationType.CREATE));
     }
 
     @Test
     void when_phoneIsTooLong_then_throwInvalidElementLengthException() {
         RestaurantModel model = new RestaurantModel(1L, "Pizza Place", "123456789", "Street 1", "+573001234567890", "logo.png", 10L);
-        assertThrows(InvalidElementLengthException.class, () -> validator.validate(model));
+        assertThrows(InvalidElementLengthException.class, () -> validator.validate(model, OperationType.CREATE));
     }
 
     @ParameterizedTest
@@ -42,7 +44,7 @@ class RestaurantPhoneValidatorTest {
         RestaurantModel model = new RestaurantModel(1L, "Pizza Place", "123456789", "Street 1", phone, "logo.png", 10L);
         InvalidElementFormatException exception = assertThrows(
                 InvalidElementFormatException.class,
-                () -> validator.validate(model),
+                () -> validator.validate(model, OperationType.CREATE),
                 "Expected InvalidElementFormatException for non-numeric phone: " + phone
         );
         assertTrue(exception.getMessage() == null || exception.getMessage().toLowerCase().contains("numeric"),

--- a/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/restaurant/impl/RestaurantRequiredFieldsValidatorTest.java
+++ b/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/restaurant/impl/RestaurantRequiredFieldsValidatorTest.java
@@ -1,5 +1,7 @@
 package com.plazoleta.foodcourtmicroservice.domain.validation.restaurant.impl;
 
+import com.plazoleta.foodcourtmicroservice.domain.enums.OperationType;
+
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -14,86 +16,86 @@ class RestaurantRequiredFieldsValidatorTest {
     @Test
     void when_allFieldsPresent_then_noException() {
         RestaurantModel model = new RestaurantModel(1L, "Pizza Place", "123456789", "Street 1", "+573001234567", "logo.png", 10L);
-        assertDoesNotThrow(() -> validator.validate(model));
+        assertDoesNotThrow(() -> validator.validate(model, OperationType.CREATE));
     }
 
     @Test
     void when_missingName_then_throwRequiredFieldsException() {
         RestaurantModel model = new RestaurantModel(1L, null, "123456789", "Street 1", "+573001234567", "logo.png", 10L);
-        assertThrows(RequiredFieldsException.class, () -> validator.validate(model));
+        assertThrows(RequiredFieldsException.class, () -> validator.validate(model, OperationType.CREATE));
     }
     @Test
     void when_nameIsEmpty_then_throwRequiredFieldsException() {
         RestaurantModel model = new RestaurantModel(1L, "", "123456789", "Street 1", "+573001234567", "logo.png", 10L);
-        assertThrows(RequiredFieldsException.class, () -> validator.validate(model));
+        assertThrows(RequiredFieldsException.class, () -> validator.validate(model, OperationType.CREATE));
     }
     @Test
     void when_nameIsBlank_then_throwRequiredFieldsException() {
         RestaurantModel model = new RestaurantModel(1L, "   ", "123456789", "Street 1", "+573001234567", "logo.png", 10L);
-        assertThrows(RequiredFieldsException.class, () -> validator.validate(model));
+        assertThrows(RequiredFieldsException.class, () -> validator.validate(model, OperationType.CREATE));
     }
 
     @Test
     void when_missingNit_then_throwRequiredFieldsException() {
         RestaurantModel model = new RestaurantModel(1L, "Pizza Place", null, "Street 1", "+573001234567", "logo.png", 10L);
-        assertThrows(RequiredFieldsException.class, () -> validator.validate(model));
+        assertThrows(RequiredFieldsException.class, () -> validator.validate(model, OperationType.CREATE));
     }
     @Test
     void when_nitIsEmpty_then_throwRequiredFieldsException() {
         RestaurantModel model = new RestaurantModel(1L, "Pizza Place", "", "Street 1", "+573001234567", "logo.png", 10L);
-        assertThrows(RequiredFieldsException.class, () -> validator.validate(model));
+        assertThrows(RequiredFieldsException.class, () -> validator.validate(model, OperationType.CREATE));
     }
     @Test
     void when_nitIsBlank_then_throwRequiredFieldsException() {
         RestaurantModel model = new RestaurantModel(1L, "Pizza Place", "   ", "Street 1", "+573001234567", "logo.png", 10L);
-        assertThrows(RequiredFieldsException.class, () -> validator.validate(model));
+        assertThrows(RequiredFieldsException.class, () -> validator.validate(model, OperationType.CREATE));
     }
 
     @Test
     void when_missingAddress_then_throwRequiredFieldsException() {
         RestaurantModel model = new RestaurantModel(1L, "Pizza Place", "123456789", null, "+573001234567", "logo.png", 10L);
-        assertThrows(RequiredFieldsException.class, () -> validator.validate(model));
+        assertThrows(RequiredFieldsException.class, () -> validator.validate(model, OperationType.CREATE));
     }
     @Test
     void when_addressIsEmpty_then_throwRequiredFieldsException() {
         RestaurantModel model = new RestaurantModel(1L, "Pizza Place", "123456789", "", "+573001234567", "logo.png", 10L);
-        assertThrows(RequiredFieldsException.class, () -> validator.validate(model));
+        assertThrows(RequiredFieldsException.class, () -> validator.validate(model, OperationType.CREATE));
     }
     @Test
     void when_addressIsBlank_then_throwRequiredFieldsException() {
         RestaurantModel model = new RestaurantModel(1L, "Pizza Place", "123456789", "   ", "+573001234567", "logo.png", 10L);
-        assertThrows(RequiredFieldsException.class, () -> validator.validate(model));
+        assertThrows(RequiredFieldsException.class, () -> validator.validate(model, OperationType.CREATE));
     }
 
     @Test
     void when_missingPhone_then_throwRequiredFieldsException() {
         RestaurantModel model = new RestaurantModel(1L, "Pizza Place", "123456789", "Street 1", null, "logo.png", 10L);
-        assertThrows(RequiredFieldsException.class, () -> validator.validate(model));
+        assertThrows(RequiredFieldsException.class, () -> validator.validate(model, OperationType.CREATE));
     }
     @Test
     void when_phoneIsEmpty_then_throwRequiredFieldsException() {
         RestaurantModel model = new RestaurantModel(1L, "Pizza Place", "123456789", "Street 1", "", "logo.png", 10L);
-        assertThrows(RequiredFieldsException.class, () -> validator.validate(model));
+        assertThrows(RequiredFieldsException.class, () -> validator.validate(model, OperationType.CREATE));
     }
     @Test
     void when_phoneIsBlank_then_throwRequiredFieldsException() {
         RestaurantModel model = new RestaurantModel(1L, "Pizza Place", "123456789", "Street 1", "   ", "logo.png", 10L);
-        assertThrows(RequiredFieldsException.class, () -> validator.validate(model));
+        assertThrows(RequiredFieldsException.class, () -> validator.validate(model, OperationType.CREATE));
     }
 
     @Test
     void when_missingUrlLogo_then_throwRequiredFieldsException() {
         RestaurantModel model = new RestaurantModel(1L, "Pizza Place", "123456789", "Street 1", "+573001234567", null, 10L);
-        assertThrows(RequiredFieldsException.class, () -> validator.validate(model));
+        assertThrows(RequiredFieldsException.class, () -> validator.validate(model, OperationType.CREATE));
     }
     @Test
     void when_urlLogoIsEmpty_then_throwRequiredFieldsException() {
         RestaurantModel model = new RestaurantModel(1L, "Pizza Place", "123456789", "Street 1", "+573001234567", "", 10L);
-        assertThrows(RequiredFieldsException.class, () -> validator.validate(model));
+        assertThrows(RequiredFieldsException.class, () -> validator.validate(model, OperationType.CREATE));
     }
     @Test
     void when_urlLogoIsBlank_then_throwRequiredFieldsException() {
         RestaurantModel model = new RestaurantModel(1L, "Pizza Place", "123456789", "Street 1", "+573001234567", "   ", 10L);
-        assertThrows(RequiredFieldsException.class, () -> validator.validate(model));
+        assertThrows(RequiredFieldsException.class, () -> validator.validate(model, OperationType.CREATE));
     }
 }


### PR DESCRIPTION
- Refactored Dish validation logic to support contextual validation (CREATE/UPDATE) using COR pattern.
- Centralized validation messages in DomainMessagesConstants.
- Updated Swagger/OpenAPI documentation for Dish endpoints and DTOs.
- Fixed and improved Dish-related unit tests to match new validation signature.
- Maintained high test coverage in domain layer.

Please review the changes for HU4. All Dish and Restaurant validation tests pass.

Closes #HU4