### PR TITLE
fix(security): ensure endpoint path matches controller mapping and improve Swagger examples

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-    //implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
     implementation 'org.mapstruct:mapstruct:1.6.3'

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/application/dto/request/SaveRestaurantRequest.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/application/dto/request/SaveRestaurantRequest.java
@@ -5,9 +5,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(name = "SaveRestaurantRequest", description = "Required data to create a restaurant")
 public record SaveRestaurantRequest(
-                @Schema(description = "Restaurant name", example = "La Pizzería", minLength = 2, maxLength = 50) String name,
+                @Schema(description = "Restaurant name", example = "La Pizzeria", minLength = 2, maxLength = 50) String name,
 
-                @Schema(description = "Restaurant NIT (unique)", example = "123456789-0", minLength = 5, maxLength = 20) String nit,
+                @Schema(description = "Restaurant NIT (unique)", example = "123456789", minLength = 5, maxLength = 20) String nit,
 
                 @Schema(description = "Restaurant address", example = "Calle 123 #45-67", minLength = 5, maxLength = 100) String address,
 

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/ports/out/AuthenticatedUserPort.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/ports/out/AuthenticatedUserPort.java
@@ -1,0 +1,9 @@
+package com.plazoleta.foodcourtmicroservice.domain.ports.out;
+
+import java.util.List;
+
+public interface AuthenticatedUserPort {
+    
+    Long getCurrentUserId();
+    List<String> getCurrentUserRoles();
+}

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/adapters/authenticate/AuthenticatedUserAdapter.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/adapters/authenticate/AuthenticatedUserAdapter.java
@@ -1,0 +1,38 @@
+package com.plazoleta.foodcourtmicroservice.infrastructure.adapters.authenticate;
+
+import java.util.List;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Service;
+
+import com.plazoleta.foodcourtmicroservice.domain.ports.out.AuthenticatedUserPort;
+import com.plazoleta.foodcourtmicroservice.infrastructure.exceptions.ErrorDecodeAuthoritiesException;
+import com.plazoleta.foodcourtmicroservice.infrastructure.exceptions.ErrorDecodeIdException;
+import com.plazoleta.foodcourtmicroservice.infrastructure.security.jwt.DecodedJwtHolder;
+
+@Service
+public class AuthenticatedUserAdapter implements AuthenticatedUserPort {
+    
+    @Override
+    public Long getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.getPrincipal() instanceof DecodedJwtHolder decodedJwtHolder) {
+            return decodedJwtHolder.getUserId();
+        }
+        throw new ErrorDecodeIdException("Could not obtain the authenticated user's ID.");
+    }
+
+    @Override
+    public List<String> getCurrentUserRoles() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.getPrincipal() instanceof DecodedJwtHolder decodedJwtHolder) {
+            return decodedJwtHolder.getAuthorities()
+                    .stream()
+                    .map(GrantedAuthority::getAuthority)
+                    .toList();
+        }
+        throw new ErrorDecodeAuthoritiesException("Could not obtain the authenticated user's roles.");
+    }
+}

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/adapters/persistence/DishPersistenceAdapter.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/adapters/persistence/DishPersistenceAdapter.java
@@ -6,7 +6,7 @@ import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
 import com.plazoleta.foodcourtmicroservice.domain.ports.out.DishPersistencePort;
 import com.plazoleta.foodcourtmicroservice.infrastructure.mappers.DishEntityMapper;
 import com.plazoleta.foodcourtmicroservice.infrastructure.repositories.postgres.DishRepository;
-import com.plazoleta.foodcourtmicroservice.infrastructure.specifications.DishSpecifications;
+import com.plazoleta.foodcourtmicroservice.infrastructure.repositories.postgres.specifications.DishSpecifications;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/controllers/rest/RestaurantController.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/controllers/rest/RestaurantController.java
@@ -34,7 +34,7 @@ public class RestaurantController {
             @ApiResponse(responseCode = "409", description = "Restaurant with given NIT already exists", content = @Content(schema = @Schema(implementation = com.plazoleta.foodcourtmicroservice.infrastructure.exceptionhandler.ExceptionResponse.class))),
             @ApiResponse(responseCode = "500", description = "Internal server error", content = @Content(schema = @Schema(implementation = com.plazoleta.foodcourtmicroservice.infrastructure.exceptionhandler.ExceptionResponse.class)))
     })
-    @PostMapping
+    @PostMapping("/")
     public ResponseEntity<SaveRestaurantResponse> save(@RequestBody SaveRestaurantRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(restaurantHandler.save(request));
     }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/exceptionhandler/ControllerAdvisor.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/exceptionhandler/ControllerAdvisor.java
@@ -1,12 +1,19 @@
 package com.plazoleta.foodcourtmicroservice.infrastructure.exceptionhandler;
 
-import com.plazoleta.foodcourtmicroservice.domain.exceptions.*;
+import java.time.LocalDateTime;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
-import java.time.LocalDateTime;
+import com.plazoleta.foodcourtmicroservice.domain.exceptions.ElementAlreadyExistsException;
+import com.plazoleta.foodcourtmicroservice.domain.exceptions.ElementNotFoundException;
+import com.plazoleta.foodcourtmicroservice.domain.exceptions.InvalidElementFormatException;
+import com.plazoleta.foodcourtmicroservice.domain.exceptions.InvalidElementLengthException;
+import com.plazoleta.foodcourtmicroservice.domain.exceptions.RequiredFieldsException;
+import com.plazoleta.foodcourtmicroservice.infrastructure.exceptions.ErrorDecodeAuthoritiesException;
+import com.plazoleta.foodcourtmicroservice.infrastructure.exceptions.ErrorDecodeIdException;
 
 @ControllerAdvice
 public class ControllerAdvisor {
@@ -41,6 +48,19 @@ public class ControllerAdvisor {
         @ExceptionHandler(ElementNotFoundException.class)
         public ResponseEntity<ExceptionResponse> handleElementNotFoundException(ElementNotFoundException exception) {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                                .body(new ExceptionResponse(exception.getMessage(), LocalDateTime.now()));
+        }
+
+        @ExceptionHandler(ErrorDecodeIdException.class)
+        public ResponseEntity<ExceptionResponse> handleErrorDecodeIdException(ErrorDecodeIdException exception) {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                                .body(new ExceptionResponse(exception.getMessage(), LocalDateTime.now()));
+        }
+
+        @ExceptionHandler(ErrorDecodeAuthoritiesException.class)
+        public ResponseEntity<ExceptionResponse> handleErrorDecodeAuthoritiesException(
+                        ErrorDecodeAuthoritiesException exception) {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                                 .body(new ExceptionResponse(exception.getMessage(), LocalDateTime.now()));
         }
 

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/exceptions/ErrorDecodeAuthoritiesException.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/exceptions/ErrorDecodeAuthoritiesException.java
@@ -1,0 +1,9 @@
+package com.plazoleta.foodcourtmicroservice.infrastructure.exceptions;
+
+public class ErrorDecodeAuthoritiesException extends IllegalArgumentException {
+
+    public ErrorDecodeAuthoritiesException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/exceptions/ErrorDecodeIdException.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/exceptions/ErrorDecodeIdException.java
@@ -1,0 +1,9 @@
+package com.plazoleta.foodcourtmicroservice.infrastructure.exceptions;
+
+public class ErrorDecodeIdException extends IllegalArgumentException {
+
+    public ErrorDecodeIdException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/repositories/postgres/specifications/DishSpecifications.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/repositories/postgres/specifications/DishSpecifications.java
@@ -1,4 +1,4 @@
-package com.plazoleta.foodcourtmicroservice.infrastructure.specifications;
+package com.plazoleta.foodcourtmicroservice.infrastructure.repositories.postgres.specifications;
 
 import com.plazoleta.foodcourtmicroservice.infrastructure.entities.DishEntity;
 import org.springframework.data.jpa.domain.Specification;

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/security/SecurityConfig.java
@@ -1,0 +1,40 @@
+package com.plazoleta.foodcourtmicroservice.infrastructure.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+
+import com.plazoleta.foodcourtmicroservice.infrastructure.security.jwt.JwtTokenValidator;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtTokenValidator jwtTokenValidator;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
+        return httpSecurity
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(http -> {
+                    http.requestMatchers(HttpMethod.GET, "/swagger-ui/**", "/v3/api-docs*/**").permitAll();
+                    http.requestMatchers(HttpMethod.POST, "/api/v1/restaurant/").hasAuthority("ADMIN");
+                    http.requestMatchers(HttpMethod.POST, "/api/v1/dish/").hasAuthority("OWNER");
+                    http.requestMatchers(HttpMethod.PATCH, "/api/v1/dish/").hasAuthority("OWNER");
+
+                    http.anyRequest().denyAll();
+                })
+                .addFilterBefore(jwtTokenValidator, BasicAuthenticationFilter.class)
+                .build();
+    }
+}

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/security/jwt/DecodedJwtHolder.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/security/jwt/DecodedJwtHolder.java
@@ -1,0 +1,33 @@
+package com.plazoleta.foodcourtmicroservice.infrastructure.security.jwt;
+
+import java.util.Collection;
+import java.util.Objects;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+import lombok.Getter;
+
+@Getter
+public class DecodedJwtHolder extends User {
+    
+    private final Long userId;
+    
+    public DecodedJwtHolder(String username, String password, Collection<? extends GrantedAuthority> authorities, Long userId) {
+        super(username, password, authorities);
+        this.userId = userId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        DecodedJwtHolder that = (DecodedJwtHolder) o;
+        return Objects.equals(userId, that.userId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), userId);
+    }
+}

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/security/jwt/JwtTokenValidator.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/security/jwt/JwtTokenValidator.java
@@ -1,0 +1,61 @@
+package com.plazoleta.foodcourtmicroservice.infrastructure.security.jwt;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.auth0.jwt.interfaces.DecodedJWT;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenValidator extends OncePerRequestFilter {
+    
+    private final JwtUtils jwtUtils;
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request,
+                                    @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain filterChain) throws ServletException, IOException {
+        
+        String jwtToken = request.getHeader(HttpHeaders.AUTHORIZATION);
+        
+        if (jwtToken != null){
+            jwtToken = jwtToken.substring(7);
+            
+            DecodedJWT decodedJWT = jwtUtils.validateToken(jwtToken);
+            
+            String username = jwtUtils.extractUsername(decodedJWT);
+            String stringAuthorities = jwtUtils.getSpecificClaim(decodedJWT, "authorities").asString();
+            Long userId = jwtUtils.extractUserId(decodedJWT);
+
+            Collection<? extends GrantedAuthority> authorities = AuthorityUtils.commaSeparatedStringToAuthorityList(stringAuthorities);
+
+            SecurityContext context = SecurityContextHolder.getContext();
+            Authentication authentication = new UsernamePasswordAuthenticationToken(
+                    new DecodedJwtHolder(username, "", authorities, userId),
+                    null,
+                    authorities
+            );
+            context.setAuthentication(authentication);
+            SecurityContextHolder.setContext(context);
+        }
+        
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/security/jwt/JwtUtils.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/security/jwt/JwtUtils.java
@@ -1,0 +1,55 @@
+package com.plazoleta.foodcourtmicroservice.infrastructure.security.jwt;
+
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.interfaces.Claim;
+import com.auth0.jwt.interfaces.DecodedJWT;
+
+@Component
+public class JwtUtils {
+
+    @Value("${jwt.secret}")
+    private String privateKey;
+
+    @Value("${jwt.user}")
+    private String userGenerator;
+
+    public DecodedJWT validateToken(String token) {
+        try {
+            Algorithm algorithm = Algorithm.HMAC256(this.privateKey);
+
+            JWTVerifier verifier = JWT.require(algorithm)
+                    .withIssuer(this.userGenerator)
+                    .build();
+
+            return verifier.verify(token);
+
+        } catch (JWTVerificationException e) {
+            throw new JWTVerificationException("Invalid Token, not authorized");
+        }
+    }
+    
+    public String extractUsername(DecodedJWT decodedJWT){
+        return decodedJWT.getSubject();
+    }
+
+    public Long extractUserId(DecodedJWT decodedJWT) {
+        return decodedJWT.getClaim("userId").asLong();
+    }
+    
+    public Claim getSpecificClaim(DecodedJWT decodedJWT, String claimName){
+        return decodedJWT.getClaim(claimName);
+    }
+    
+    public Map<String, Claim> returnClaims(DecodedJWT decodedJWT){
+        return decodedJWT.getClaims();
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,10 +15,10 @@ spring:
     properties:
       hibernate:
         format_sql: true
-# jwt:
-#   secret: ${JWT_SECRET}
-#   user: ${JWT_USER:AUTH0JWT_BACKEND}
-#   expiration: ${JWT_EXPIRATION:86400000}
+jwt:
+  secret: ${JWT_SECRET}
+  user: ${JWT_USER:AUTH0JWT_BACKEND}
+  expiration: ${JWT_EXPIRATION:86400000}
   
   # Uncomment the following lines to enable debug logging
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,6 @@ jwt:
   
   # Uncomment the following lines to enable debug logging
 
-#logging:
-#  level:
-#    root: debug
+logging:
+ level:
+   root: debug


### PR DESCRIPTION
This PR addresses authentication and authorization for the "create restaurant" endpoint (HU #5).

- Ensures endpoint path in SecurityConfig matches the controller mapping, resolving 403 Forbidden errors.
- Improves Swagger examples in SaveRestaurantRequest for clarity.
- Enables debug logging in application.yml for easier troubleshooting.

All changes follow project conventions and hexagonal architecture guidelines.