### PR TITLE
feat(HU2): Require ADMIN role to create restaurant, update tests and constants

### DIFF
--- a/src/main/java/com/plazoleta/foodcourtmicroservice/commons/config/beans/RestaurantBeanConfiguration.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/commons/config/beans/RestaurantBeanConfiguration.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Configuration;
 
 import com.plazoleta.foodcourtmicroservice.application.client.handler.UserHandlerClient;
 import com.plazoleta.foodcourtmicroservice.domain.ports.in.RestaurantServicePort;
+import com.plazoleta.foodcourtmicroservice.domain.ports.out.AuthenticatedUserPort;
 import com.plazoleta.foodcourtmicroservice.domain.ports.out.RestaurantPersistencePort;
 import com.plazoleta.foodcourtmicroservice.domain.ports.out.UserServicePort;
 import com.plazoleta.foodcourtmicroservice.domain.usecases.RestaurantUseCase;
@@ -16,8 +17,8 @@ import com.plazoleta.foodcourtmicroservice.infrastructure.repositories.postgres.
 
 import lombok.RequiredArgsConstructor;
 
-@Configuration
 @RequiredArgsConstructor
+@Configuration
 public class RestaurantBeanConfiguration {
 
     private final RestaurantRepository restaurantRepository;
@@ -43,10 +44,13 @@ public class RestaurantBeanConfiguration {
     public RestaurantServicePort restaurantServicePort(
             RestaurantPersistencePort restaurantPersistencePort,
             RestaurantValidatorChain restaurantValidatorChain,
-            UserServicePort userServicePort
-            ) {
+            UserServicePort userServicePort,
+            AuthenticatedUserPort authenticatedUserPort) {
         return new RestaurantUseCase(
-                restaurantPersistencePort, restaurantValidatorChain, userServicePort);
+                restaurantPersistencePort,
+                restaurantValidatorChain,
+                userServicePort,
+                authenticatedUserPort);
     }
 
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/utils/constants/DomainMessagesConstants.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/utils/constants/DomainMessagesConstants.java
@@ -1,7 +1,9 @@
 
+
 package com.plazoleta.foodcourtmicroservice.domain.utils.constants;
 
 public final class DomainMessagesConstants {
+    public static final String USER_NOT_AUTHORIZED_TO_CREATE_RESTAURANT = "Only users with ADMIN role can create a restaurant.";
 
     public static final String USER_IS_NOT_OWNER = "The user with id %d is not an OWNER.";
     public static final String USER_DOES_NOT_EXIST = "The user with id %d does not exist.";


### PR DESCRIPTION
## Summary

This PR refactors the restaurant creation logic to enforce business security rules:

- Only authenticated users with the ADMIN role can create a restaurant (RestaurantUseCase).
- Adds the USER_NOT_AUTHORIZED_TO_CREATE_RESTAURANT constant for consistent error handling.
- Updates RestaurantBeanConfiguration for proper dependency injection.
- Refactors and extends RestaurantUseCaseTest to cover ADMIN role validation and error cases.
- All tests passing and domain logic covered.

**Context:**
This is a refactor to apply security and business rules as required by HU2. No API contract changes, but now only ADMIN users can create restaurants, and this is validated before ownerId role check.

**Branch:** feature/hu2-create-restaurant
**Target:** develop

Please review and merge if all is correct.