### PR TITLE
feat: implement list dishes by restaurant/category (HU#10) + architecture improvements

### DIFF
--- a/src/main/java/com/plazoleta/foodcourtmicroservice/application/dto/request/SaveDishRequest.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/application/dto/request/SaveDishRequest.java
@@ -5,21 +5,15 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(name = "SaveDishRequest", description = "Request body for creating a new dish.")
 public record SaveDishRequest(
-    @Schema(description = "Dish name", example = "Classic Burger")
-    String name,
+        @Schema(description = "Dish name", example = "Classic Burger") String name,
 
-    @Schema(description = "Dish price (integer, greater than 0)", example = "15000")
-    Integer price,
+        @Schema(description = "Dish price (integer, greater than 0)", example = "15000") Integer price,
 
-    @Schema(description = "Dish description", example = "Juicy beef burger with cheddar cheese and fresh vegetables.")
-    String description,
+        @Schema(description = "Dish description", example = "Juicy beef burger with cheddar cheese and fresh vegetables.") String description,
 
-    @Schema(description = "Image URL (http or https, ends with jpg/png/jpeg/gif/bmp)", example = "https://cdn.example.com/img/burger.jpg")
-    String urlImage,
+        @Schema(description = "Image URL (http or https, ends with jpg/png/jpeg/gif/bmp)", example = "https://cdn.example.com/img/burger.jpg") String urlImage,
 
-    @Schema(description = "Category ID", example = "1")
-    Long categoryId,
+        @Schema(description = "Category ID", example = "2") Long categoryId,
 
-    @Schema(description = "Restaurant ID", example = "10")
-    Long restaurantId
-) {}
+        @Schema(description = "Restaurant ID", example = "10") Long restaurantId) {
+}

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/application/dto/response/DishResponse.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/application/dto/response/DishResponse.java
@@ -1,0 +1,14 @@
+package com.plazoleta.foodcourtmicroservice.application.dto.response;
+
+import java.math.BigDecimal;
+
+public record DishResponse(
+    Long id,
+    String name,
+    BigDecimal price,
+    String description,
+    String urlImage,
+    Long categoryId,
+    String restaurantName
+) {
+}

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/application/dto/response/DishResponse.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/application/dto/response/DishResponse.java
@@ -2,13 +2,16 @@ package com.plazoleta.foodcourtmicroservice.application.dto.response;
 
 import java.math.BigDecimal;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "DishResponse", description = "Response body for dish data.")
 public record DishResponse(
-    Long id,
-    String name,
-    BigDecimal price,
-    String description,
-    String urlImage,
-    Long categoryId,
-    String restaurantName
-) {
+        @Schema(description = "Dish ID", example = "1") Long id,
+        @Schema(description = "Dish name", example = "Classic Burger") String name,
+        @Schema(description = "Dish price", example = "15000.00") BigDecimal price,
+        @Schema(description = "Dish description", example = "Juicy beef burger with cheddar cheese and fresh vegetables.") String description,
+        @Schema(description = "Image URL", example = "https://cdn.example.com/img/burger.jpg") String urlImage,
+        @Schema(description = "Category name", example = "Burgers") String categoryName,
+        @Schema(description = "Restaurant name", example = "Burger House") String restaurantName) {
+
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/application/handler/DishHandler.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/application/handler/DishHandler.java
@@ -1,11 +1,12 @@
 package com.plazoleta.foodcourtmicroservice.application.handler;
 
 import com.plazoleta.foodcourtmicroservice.application.dto.request.SaveDishRequest;
+import com.plazoleta.foodcourtmicroservice.application.dto.request.SetDishActiveRequest;
 import com.plazoleta.foodcourtmicroservice.application.dto.request.UpdateDishRequest;
+import com.plazoleta.foodcourtmicroservice.application.dto.response.DishResponse;
 import com.plazoleta.foodcourtmicroservice.application.dto.response.SaveDishResponse;
 import com.plazoleta.foodcourtmicroservice.application.dto.response.UpdateDishResponse;
-
-import com.plazoleta.foodcourtmicroservice.application.dto.request.SetDishActiveRequest;
+import com.plazoleta.foodcourtmicroservice.domain.utils.pagination.PageInfo;
 
 public interface DishHandler {
     SaveDishResponse save(SaveDishRequest request);
@@ -13,4 +14,7 @@ public interface DishHandler {
     UpdateDishResponse update(Long dishId, UpdateDishRequest request);
     
     void setActive(Long dishId, SetDishActiveRequest request);
+
+
+    PageInfo<DishResponse> findAllByRestaurantId(Long restaurantId, Long categoryId, Integer page, Integer size, String sortBy, boolean orderAsc);
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/application/handler/impl/DishHandlerImpl.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/application/handler/impl/DishHandlerImpl.java
@@ -1,18 +1,23 @@
 package com.plazoleta.foodcourtmicroservice.application.handler.impl;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.springframework.stereotype.Service;
 
 import com.plazoleta.foodcourtmicroservice.application.dto.request.SaveDishRequest;
 import com.plazoleta.foodcourtmicroservice.application.dto.request.SetDishActiveRequest;
 import com.plazoleta.foodcourtmicroservice.application.dto.request.UpdateDishRequest;
+import com.plazoleta.foodcourtmicroservice.application.dto.response.DishResponse;
 import com.plazoleta.foodcourtmicroservice.application.dto.response.SaveDishResponse;
 import com.plazoleta.foodcourtmicroservice.application.dto.response.UpdateDishResponse;
 import com.plazoleta.foodcourtmicroservice.application.handler.DishHandler;
 import com.plazoleta.foodcourtmicroservice.application.mappers.DishRequestMapper;
+import com.plazoleta.foodcourtmicroservice.application.mappers.DishResponseMapper;
 import com.plazoleta.foodcourtmicroservice.application.utils.constants.ApplicationMessagesConstants;
+import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
 import com.plazoleta.foodcourtmicroservice.domain.ports.in.DishServicePort;
+import com.plazoleta.foodcourtmicroservice.domain.utils.pagination.PageInfo;
 
 import lombok.RequiredArgsConstructor;
 
@@ -22,6 +27,7 @@ public class DishHandlerImpl implements DishHandler {
 
     private final DishRequestMapper dishRequestMapper;
     private final DishServicePort dishServicePort;
+    private final DishResponseMapper dishResponseMapper;
 
     @Override
     public SaveDishResponse save(SaveDishRequest request) {
@@ -38,5 +44,23 @@ public class DishHandlerImpl implements DishHandler {
     @Override
     public void setActive(Long dishId, SetDishActiveRequest request) {
         dishServicePort.setDishActive(dishId, request.getRestaurantId(), request.getActive());
+    }
+
+    @Override
+    public PageInfo<DishResponse> findAllByRestaurantId(Long restaurantId, Long categoryId, Integer page, Integer size,
+            String sortBy, boolean orderAsc) {
+        PageInfo<DishModel> dishPageInfo = dishServicePort.findAllByRestaurantId(restaurantId, categoryId, page, size,
+                sortBy, orderAsc);
+        List<DishResponse> dishResponses = dishPageInfo.getContent().stream()
+                .map(dishResponseMapper::modelToResponse)
+                .toList();
+        return new PageInfo<>(
+                dishResponses,
+                dishPageInfo.getTotalElements(),
+                dishPageInfo.getTotalPages(),
+                dishPageInfo.getCurrentPage(),
+                dishPageInfo.getPageSize(),
+                dishPageInfo.isHasNext(),
+                dishPageInfo.isHasPrevious());
     }
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/application/mappers/DishRequestMapper.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/application/mappers/DishRequestMapper.java
@@ -1,17 +1,18 @@
 package com.plazoleta.foodcourtmicroservice.application.mappers;
 
 import org.mapstruct.Mapper;
-import com.plazoleta.foodcourtmicroservice.application.dto.request.SaveDishRequest;
-import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
-
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
+import com.plazoleta.foodcourtmicroservice.application.dto.request.SaveDishRequest;
+import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
 import com.plazoleta.foodcourtmicroservice.domain.model.RestaurantModel;
+import com.plazoleta.foodcourtmicroservice.domain.model.CategoryModel;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = org.mapstruct.ReportingPolicy.IGNORE)
 public interface DishRequestMapper {
 
     @Mapping(target = "restaurant", source = "restaurantId", qualifiedByName = "restaurantIdToRestaurantModel")
+    @Mapping(target = "category", source = "categoryId", qualifiedByName = "categoryIdToCategoryModel")
     DishModel requestToModel(SaveDishRequest request);
 
     @Named("restaurantIdToRestaurantModel")
@@ -22,5 +23,16 @@ public interface DishRequestMapper {
         RestaurantModel restaurant = new RestaurantModel();
         restaurant.setId(restaurantId);
         return restaurant;
+    }
+
+    @Named("categoryIdToCategoryModel")
+    default CategoryModel categoryIdToCategoryModel(Long categoryId) {
+        if (categoryId == null) {
+            return null;
+        }
+        CategoryModel category = new CategoryModel();
+        category.setId(categoryId);
+        return category;
+
     }
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/application/mappers/DishResponseMapper.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/application/mappers/DishResponseMapper.java
@@ -11,5 +11,6 @@ import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
 public interface DishResponseMapper {
 
     @Mapping(source = "restaurant.name", target = "restaurantName")
+    @Mapping(source = "category.name", target = "categoryName")
     DishResponse modelToResponse(DishModel dishModel);
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/application/mappers/DishResponseMapper.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/application/mappers/DishResponseMapper.java
@@ -1,0 +1,15 @@
+package com.plazoleta.foodcourtmicroservice.application.mappers;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+import com.plazoleta.foodcourtmicroservice.application.dto.response.DishResponse;
+import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface DishResponseMapper {
+
+    @Mapping(source = "restaurant.name", target = "restaurantName")
+    DishResponse modelToResponse(DishModel dishModel);
+}

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/commons/config/beans/DishBeanConfiguration.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/commons/config/beans/DishBeanConfiguration.java
@@ -1,5 +1,7 @@
 package com.plazoleta.foodcourtmicroservice.commons.config.beans;
 
+import java.util.Set;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -8,6 +10,7 @@ import com.plazoleta.foodcourtmicroservice.domain.ports.out.AuthenticatedUserPor
 import com.plazoleta.foodcourtmicroservice.domain.ports.out.DishPersistencePort;
 import com.plazoleta.foodcourtmicroservice.domain.usecases.DishUseCase;
 import com.plazoleta.foodcourtmicroservice.domain.validation.dish.DishValidatorChain;
+import com.plazoleta.foodcourtmicroservice.domain.validation.pagination.PaginationValidatorChain;
 import com.plazoleta.foodcourtmicroservice.infrastructure.adapters.persistence.DishPersistenceAdapter;
 import com.plazoleta.foodcourtmicroservice.infrastructure.mappers.DishEntityMapper;
 import com.plazoleta.foodcourtmicroservice.infrastructure.repositories.postgres.DishRepository;
@@ -32,10 +35,16 @@ public class DishBeanConfiguration {
     }
 
     @Bean
+    public PaginationValidatorChain dishPaginationValidatorChain() {
+        return new PaginationValidatorChain(Set.of("name", "price", "description", "category", "active"));
+    }
+
+    @Bean
     public DishServicePort dishServicePort(
             DishPersistencePort dishPersistencePort,
             DishValidatorChain dishValidatorChain,
-            AuthenticatedUserPort authenticatedUserPort) {
-        return new DishUseCase(dishPersistencePort, dishValidatorChain, authenticatedUserPort);
+            AuthenticatedUserPort authenticatedUserPort,
+            PaginationValidatorChain dishPaginationValidatorChain) {
+        return new DishUseCase(dishPersistencePort, dishValidatorChain, authenticatedUserPort, dishPaginationValidatorChain);
     }
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/commons/config/beans/DishBeanConfiguration.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/commons/config/beans/DishBeanConfiguration.java
@@ -9,6 +9,7 @@ import com.plazoleta.foodcourtmicroservice.domain.ports.in.DishServicePort;
 import com.plazoleta.foodcourtmicroservice.domain.ports.out.AuthenticatedUserPort;
 import com.plazoleta.foodcourtmicroservice.domain.ports.out.DishPersistencePort;
 import com.plazoleta.foodcourtmicroservice.domain.ports.out.RestaurantPersistencePort;
+import com.plazoleta.foodcourtmicroservice.domain.ports.out.CategoryPersistencePort;
 import com.plazoleta.foodcourtmicroservice.domain.usecases.DishUseCase;
 import com.plazoleta.foodcourtmicroservice.domain.validation.dish.DishValidatorChain;
 import com.plazoleta.foodcourtmicroservice.domain.validation.pagination.PaginationValidatorChain;
@@ -46,11 +47,13 @@ public class DishBeanConfiguration {
             DishValidatorChain dishValidatorChain,
             AuthenticatedUserPort authenticatedUserPort,
             PaginationValidatorChain dishPaginationValidatorChain,
-            RestaurantPersistencePort restaurantPersistencePort) {
+            RestaurantPersistencePort restaurantPersistencePort,
+            CategoryPersistencePort categoryPersistencePort) {
         return new DishUseCase(dishPersistencePort,
                 dishValidatorChain,
                 authenticatedUserPort,
                 dishPaginationValidatorChain,
-                restaurantPersistencePort);
+                restaurantPersistencePort,
+                categoryPersistencePort);
     }
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/commons/config/beans/DishBeanConfiguration.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/commons/config/beans/DishBeanConfiguration.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Configuration;
 import com.plazoleta.foodcourtmicroservice.domain.ports.in.DishServicePort;
 import com.plazoleta.foodcourtmicroservice.domain.ports.out.AuthenticatedUserPort;
 import com.plazoleta.foodcourtmicroservice.domain.ports.out.DishPersistencePort;
+import com.plazoleta.foodcourtmicroservice.domain.ports.out.RestaurantPersistencePort;
 import com.plazoleta.foodcourtmicroservice.domain.usecases.DishUseCase;
 import com.plazoleta.foodcourtmicroservice.domain.validation.dish.DishValidatorChain;
 import com.plazoleta.foodcourtmicroservice.domain.validation.pagination.PaginationValidatorChain;
@@ -44,7 +45,12 @@ public class DishBeanConfiguration {
             DishPersistencePort dishPersistencePort,
             DishValidatorChain dishValidatorChain,
             AuthenticatedUserPort authenticatedUserPort,
-            PaginationValidatorChain dishPaginationValidatorChain) {
-        return new DishUseCase(dishPersistencePort, dishValidatorChain, authenticatedUserPort, dishPaginationValidatorChain);
+            PaginationValidatorChain dishPaginationValidatorChain,
+            RestaurantPersistencePort restaurantPersistencePort) {
+        return new DishUseCase(dishPersistencePort,
+                dishValidatorChain,
+                authenticatedUserPort,
+                dishPaginationValidatorChain,
+                restaurantPersistencePort);
     }
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/model/CategoryModel.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/model/CategoryModel.java
@@ -1,0 +1,19 @@
+package com.plazoleta.foodcourtmicroservice.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Domain model for Category.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CategoryModel {
+    private Long id;
+    private String name;
+    private String description;
+}

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/model/DishModel.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/model/DishModel.java
@@ -9,7 +9,7 @@ public class DishModel {
     private BigDecimal price;
     private String description;
     private String urlImage;
-    private Long categoryId;
+    private CategoryModel category;
     private RestaurantModel restaurant;
     private Boolean active;
 
@@ -17,14 +17,14 @@ public class DishModel {
         this.active = true;
     }
 
-    public DishModel(Long id, String name, BigDecimal price, String description, String urlImage, Long categoryId,
-            RestaurantModel restaurant, Boolean active) {
+    public DishModel(Long id, String name, BigDecimal price, String description,
+            String urlImage, CategoryModel category, RestaurantModel restaurant, Boolean active) {
         this.id = id;
         this.name = name;
         this.price = price;
         this.description = description;
         this.urlImage = urlImage;
-        this.categoryId = categoryId;
+        this.category = category;
         this.restaurant = restaurant;
         this.active = active;
     }
@@ -69,12 +69,12 @@ public class DishModel {
         this.urlImage = urlImage;
     }
 
-    public Long getCategoryId() {
-        return categoryId;
+    public CategoryModel getCategory() {
+        return category;
     }
 
-    public void setCategoryId(Long categoryId) {
-        this.categoryId = categoryId;
+    public void setCategory(CategoryModel category) {
+        this.category = category;
     }
 
     public RestaurantModel getRestaurant() {
@@ -116,7 +116,7 @@ public class DishModel {
                 ", price=" + price +
                 ", description='" + description + '\'' +
                 ", urlImage='" + urlImage + '\'' +
-                ", categoryId=" + categoryId +
+                ", category=" + category +
                 ", restaurant=" + restaurant +
                 ", active=" + active +
                 '}';

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/ports/in/DishServicePort.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/ports/in/DishServicePort.java
@@ -3,6 +3,7 @@ package com.plazoleta.foodcourtmicroservice.domain.ports.in;
 import java.math.BigDecimal;
 
 import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
+import com.plazoleta.foodcourtmicroservice.domain.utils.pagination.PageInfo;
 
 public interface DishServicePort {
     void save(DishModel dishModel);
@@ -10,4 +11,6 @@ public interface DishServicePort {
     void updateDish(Long dishId, Long restaurantId, BigDecimal price, String description);
 
     void setDishActive(Long dishId, Long restaurantId, boolean active);
+
+    PageInfo<DishModel> findAllByRestaurantId(Long restaurantId, Long categoryId, Integer page, Integer size, String sortBy, boolean orderAsc);
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/ports/out/CategoryPersistencePort.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/ports/out/CategoryPersistencePort.java
@@ -1,0 +1,6 @@
+package com.plazoleta.foodcourtmicroservice.domain.ports.out;
+
+public interface CategoryPersistencePort {
+
+    boolean existsById(Long id);
+}

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/ports/out/DishPersistencePort.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/ports/out/DishPersistencePort.java
@@ -3,6 +3,7 @@ package com.plazoleta.foodcourtmicroservice.domain.ports.out;
 import java.math.BigDecimal;
 
 import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
+import com.plazoleta.foodcourtmicroservice.domain.utils.pagination.PageInfo;
 
 public interface DishPersistencePort {
 
@@ -17,4 +18,6 @@ public interface DishPersistencePort {
     void setDishActive(Long dishId, Long restaurantId, boolean active);
 
     boolean existsByRestaurantIdAndOwnerId(Long restaurantId, Long currentUserId);
+
+    PageInfo<DishModel> findAllByRestaurantId(Long restaurantId, Long categoryId, Integer page, Integer size, String sortBy, boolean orderAsc);
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/ports/out/RestaurantPersistencePort.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/ports/out/RestaurantPersistencePort.java
@@ -9,5 +9,7 @@ public interface RestaurantPersistencePort {
 
     boolean existsByNit(String nit);
 
+    boolean existsById(Long id);
+
     PageInfo<RestaurantModel> findAll(Integer page, Integer size, String sortBy, boolean orderAsc);
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/usecases/DishUseCase.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/usecases/DishUseCase.java
@@ -13,20 +13,25 @@ import com.plazoleta.foodcourtmicroservice.domain.ports.in.DishServicePort;
 import com.plazoleta.foodcourtmicroservice.domain.ports.out.AuthenticatedUserPort;
 import com.plazoleta.foodcourtmicroservice.domain.ports.out.DishPersistencePort;
 import com.plazoleta.foodcourtmicroservice.domain.utils.constants.DomainMessagesConstants;
+import com.plazoleta.foodcourtmicroservice.domain.utils.pagination.PageInfo;
 import com.plazoleta.foodcourtmicroservice.domain.validation.dish.DishValidatorChain;
+import com.plazoleta.foodcourtmicroservice.domain.validation.pagination.PaginationValidatorChain;
 
 public class DishUseCase implements DishServicePort {
 
     private final DishPersistencePort dishPersistencePort;
     private final DishValidatorChain dishValidatorChain;
     private final AuthenticatedUserPort authenticatedUserPort;
+    private final PaginationValidatorChain paginationValidatorChain;
 
     public DishUseCase(DishPersistencePort dishPersistencePort,
             DishValidatorChain dishValidatorChain,
-            AuthenticatedUserPort authenticatedUserPort) {
+            AuthenticatedUserPort authenticatedUserPort,
+            PaginationValidatorChain paginationValidatorChain) {
         this.dishPersistencePort = dishPersistencePort;
         this.dishValidatorChain = dishValidatorChain;
         this.authenticatedUserPort = authenticatedUserPort;
+        this.paginationValidatorChain = paginationValidatorChain;
     }
 
     @Override
@@ -109,5 +114,11 @@ public class DishUseCase implements DishServicePort {
                     String.format(DomainMessagesConstants.DISH_NOT_FOUND_IN_RESTAURANT, dishId, restaurantId));
         }
         dishPersistencePort.setDishActive(dishId, restaurantId, active);
+    }
+
+    @Override
+    public PageInfo<DishModel> findAllByRestaurantId(Long restaurantId, Long categoryId, Integer page, Integer size, String sortBy, boolean orderAsc) {
+        paginationValidatorChain.validate(page, size, sortBy, orderAsc);
+        return dishPersistencePort.findAllByRestaurantId(restaurantId, categoryId, page, size, sortBy, orderAsc);
     }
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/usecases/DishUseCase.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/usecases/DishUseCase.java
@@ -12,6 +12,7 @@ import com.plazoleta.foodcourtmicroservice.domain.model.RestaurantModel;
 import com.plazoleta.foodcourtmicroservice.domain.ports.in.DishServicePort;
 import com.plazoleta.foodcourtmicroservice.domain.ports.out.AuthenticatedUserPort;
 import com.plazoleta.foodcourtmicroservice.domain.ports.out.DishPersistencePort;
+import com.plazoleta.foodcourtmicroservice.domain.ports.out.RestaurantPersistencePort;
 import com.plazoleta.foodcourtmicroservice.domain.utils.constants.DomainMessagesConstants;
 import com.plazoleta.foodcourtmicroservice.domain.utils.pagination.PageInfo;
 import com.plazoleta.foodcourtmicroservice.domain.validation.dish.DishValidatorChain;
@@ -23,15 +24,18 @@ public class DishUseCase implements DishServicePort {
     private final DishValidatorChain dishValidatorChain;
     private final AuthenticatedUserPort authenticatedUserPort;
     private final PaginationValidatorChain paginationValidatorChain;
+    private final RestaurantPersistencePort restaurantPersistencePort;
 
     public DishUseCase(DishPersistencePort dishPersistencePort,
             DishValidatorChain dishValidatorChain,
             AuthenticatedUserPort authenticatedUserPort,
-            PaginationValidatorChain paginationValidatorChain) {
+            PaginationValidatorChain paginationValidatorChain,
+            RestaurantPersistencePort restaurantPersistencePort) {
         this.dishPersistencePort = dishPersistencePort;
         this.dishValidatorChain = dishValidatorChain;
         this.authenticatedUserPort = authenticatedUserPort;
         this.paginationValidatorChain = paginationValidatorChain;
+        this.restaurantPersistencePort = restaurantPersistencePort;
     }
 
     @Override
@@ -119,6 +123,9 @@ public class DishUseCase implements DishServicePort {
     @Override
     public PageInfo<DishModel> findAllByRestaurantId(Long restaurantId, Long categoryId, Integer page, Integer size, String sortBy, boolean orderAsc) {
         paginationValidatorChain.validate(page, size, sortBy, orderAsc);
+        if (!restaurantPersistencePort.existsById(restaurantId)) {
+            throw new ElementNotFoundException(String.format(DomainMessagesConstants.RESTAURANT_NOT_FOUND, restaurantId));
+        }
         return dishPersistencePort.findAllByRestaurantId(restaurantId, categoryId, page, size, sortBy, orderAsc);
     }
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/utils/constants/DomainMessagesConstants.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/utils/constants/DomainMessagesConstants.java
@@ -41,6 +41,7 @@ public final class DomainMessagesConstants {
     public static final String DISH_PRICE_MUST_BE_INTEGER = "Dish price must be an integer.";
     public static final String DISH_CATEGORY_ID_REQUIRED = "Category ID is required.";
     public static final String DISH_RESTAURANT_ID_REQUIRED = "Restaurant ID is required.";
+    public static final String CATEGORY_NOT_FOUND = "Category with id %d does not exist.";
 
     public static final String DISH_ALREADY_EXISTS = "A dish with the same name '%s' already exists in this restaurant.";
     public static final String DISH_NOT_FOUND_IN_RESTAURANT = "Dish with id %d does not belong to restaurant with id %d or does not exist.";

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/utils/constants/DomainMessagesConstants.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/utils/constants/DomainMessagesConstants.java
@@ -15,6 +15,8 @@ public final class DomainMessagesConstants {
     public static final String RESTAURANT_NAME_REQUIRED = "Restaurant name is required.";
     public static final String RESTAURANT_NAME_NUMERIC = "Restaurant name cannot be only numbers.";
 
+    public static final String RESTAURANT_NOT_FOUND = "Restaurant with id %d does not exist.";
+
     public static final String NAME_ONLY_NUMBERS_REGEX = "\\d+";
     public static final String NIT_NUMERIC_REGEX = "\\d+";
     public static final String PHONE_REGEX = "^\\+?\\d+$";

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishRequiredFieldsValidator.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishRequiredFieldsValidator.java
@@ -26,7 +26,7 @@ public class DishRequiredFieldsValidator extends AbstractValidator<DishModel> {
         if (dish.getRestaurant() == null || dish.getRestaurant().getId() == null) {
             throw new RequiredFieldsException(DomainMessagesConstants.DISH_RESTAURANT_ID_REQUIRED);
         }
-        if (dish.getCategoryId() == null) {
+        if (dish.getCategory() == null || dish.getCategory().getId() == null) {
             throw new RequiredFieldsException(DomainMessagesConstants.DISH_CATEGORY_ID_REQUIRED);
         }
         if (dish.getPrice() == null) {

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/adapters/persistence/CategoryPersistenceAdapter.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/adapters/persistence/CategoryPersistenceAdapter.java
@@ -1,0 +1,20 @@
+package com.plazoleta.foodcourtmicroservice.infrastructure.adapters.persistence;
+
+import org.springframework.stereotype.Repository;
+
+import com.plazoleta.foodcourtmicroservice.domain.ports.out.CategoryPersistencePort;
+import com.plazoleta.foodcourtmicroservice.infrastructure.repositories.postgres.CategoryRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class CategoryPersistenceAdapter implements CategoryPersistencePort {
+
+    private final CategoryRepository categoryRepository;
+
+    @Override
+    public boolean existsById(Long id) {
+        return categoryRepository.existsById(id);
+    }
+}

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/adapters/persistence/DishPersistenceAdapter.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/adapters/persistence/DishPersistenceAdapter.java
@@ -1,9 +1,18 @@
 package com.plazoleta.foodcourtmicroservice.infrastructure.adapters.persistence;
 
 import java.math.BigDecimal;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 
 import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
 import com.plazoleta.foodcourtmicroservice.domain.ports.out.DishPersistencePort;
+import com.plazoleta.foodcourtmicroservice.domain.utils.pagination.PageInfo;
+import com.plazoleta.foodcourtmicroservice.infrastructure.entities.DishEntity;
 import com.plazoleta.foodcourtmicroservice.infrastructure.mappers.DishEntityMapper;
 import com.plazoleta.foodcourtmicroservice.infrastructure.repositories.postgres.DishRepository;
 import com.plazoleta.foodcourtmicroservice.infrastructure.repositories.postgres.specifications.DishSpecifications;
@@ -19,12 +28,6 @@ public class DishPersistenceAdapter implements DishPersistencePort {
     @Override
     public void save(DishModel dishModel) {
         dishRepository.save(dishEntityMapper.modelToEntity(dishModel));
-    }
-
-    @Override
-    public boolean existsByNameAndRestaurantId(String name, Long restaurantId) {
-        return dishRepository.count(
-                DishSpecifications.nameEqualsIgnoreCaseAndRestaurantId(name, restaurantId)) > 0;
     }
 
     @Override
@@ -47,16 +50,52 @@ public class DishPersistenceAdapter implements DishPersistencePort {
     }
 
     @Override
+    public PageInfo<DishModel> findAllByRestaurantId(Long restaurantId, Long categoryId, Integer page, Integer size,
+            String sortBy, boolean orderAsc) {
+        Sort sort = Sort.by(sortBy);
+        if (!orderAsc) {
+            sort = sort.descending();
+        }
+
+        Pageable pageable = PageRequest.of(page, size, sort);
+
+        Specification<DishEntity> specification = DishSpecifications.restaurantIdEquals(restaurantId);
+
+        if (categoryId != null) {
+            specification = specification.and(DishSpecifications.categoryIdEquals(categoryId));
+        }
+
+        Page<DishEntity> dishEntityPage = dishRepository.findAll(specification, pageable);
+
+        List<DishModel> dishModels = dishEntityPage.getContent().stream()
+                .map(dishEntityMapper::entityToModel)
+                .toList();
+
+        return new PageInfo<>(
+                dishModels,
+                dishEntityPage.getTotalElements(),
+                dishEntityPage.getTotalPages(),
+                dishEntityPage.getNumber(),
+                dishEntityPage.getSize(),
+                dishEntityPage.hasNext(),
+                dishEntityPage.hasPrevious());
+    }
+
+    @Override
+    public boolean existsByNameAndRestaurantId(String name, Long restaurantId) {
+        return dishRepository.count(
+                DishSpecifications.nameEqualsIgnoreCaseAndRestaurantId(name, restaurantId)) > 0;
+    }
+
+    @Override
     public boolean existsByIdAndRestaurantId(Long dishId, Long restaurantId) {
         return dishRepository.count(
-            DishSpecifications.idEqualsAndRestaurantId(dishId, restaurantId)
-        ) > 0;
+                DishSpecifications.idEqualsAndRestaurantId(dishId, restaurantId)) > 0;
     }
 
     @Override
     public boolean existsByRestaurantIdAndOwnerId(Long restaurantId, Long currentUserId) {
         return dishRepository.count(
-            DishSpecifications.restaurantIdEqualsAndOwnerId(restaurantId, currentUserId)
-        ) > 0;
+                DishSpecifications.restaurantIdEqualsAndOwnerId(restaurantId, currentUserId)) > 0;
     }
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/adapters/persistence/RestaurantPersistenceAdapter.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/adapters/persistence/RestaurantPersistenceAdapter.java
@@ -33,6 +33,11 @@ public class RestaurantPersistenceAdapter implements RestaurantPersistencePort {
     }
 
     @Override
+    public boolean existsById(Long id) {
+        return restaurantRepository.existsById(id);
+    }
+
+    @Override
     public PageInfo<RestaurantModel> findAll(Integer page, Integer size, String sortBy, boolean orderAsc) {
         Sort sort  = Sort.by(sortBy);
         if (!orderAsc) {

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/controllers/rest/DishController.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/controllers/rest/DishController.java
@@ -84,6 +84,7 @@ public class DishController {
         @ApiResponses(value = {
                         @ApiResponse(responseCode = "200", description = "Dishes retrieved successfully"),
                         @ApiResponse(responseCode = "400", description = "Invalid pagination parameters", content = @Content(schema = @Schema(implementation = ExceptionResponse.class))),
+                        @ApiResponse(responseCode = "404", description = "Restaurant not found", content = @Content(schema = @Schema(implementation = ExceptionResponse.class))),
                         @ApiResponse(responseCode = "500", description = "Internal server error", content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
         })
         @GetMapping("/restaurant/{restaurantId}")

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/controllers/rest/DishController.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/controllers/rest/DishController.java
@@ -2,19 +2,23 @@ package com.plazoleta.foodcourtmicroservice.infrastructure.controllers.rest;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.plazoleta.foodcourtmicroservice.application.dto.request.SaveDishRequest;
 import com.plazoleta.foodcourtmicroservice.application.dto.request.SetDishActiveRequest;
 import com.plazoleta.foodcourtmicroservice.application.dto.request.UpdateDishRequest;
+import com.plazoleta.foodcourtmicroservice.application.dto.response.DishResponse;
 import com.plazoleta.foodcourtmicroservice.application.dto.response.SaveDishResponse;
 import com.plazoleta.foodcourtmicroservice.application.dto.response.UpdateDishResponse;
 import com.plazoleta.foodcourtmicroservice.application.handler.DishHandler;
+import com.plazoleta.foodcourtmicroservice.domain.utils.pagination.PageInfo;
 import com.plazoleta.foodcourtmicroservice.infrastructure.exceptionhandler.ExceptionResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -74,5 +78,23 @@ public class DishController {
                         @RequestBody SetDishActiveRequest request) {
                 dishHandler.setActive(id, request);
                 return ResponseEntity.ok().build();
+        }
+
+        @Operation(summary = "List dishes by restaurant", description = "Returns a paginated list of dishes for a specific restaurant, with optional category filter.")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "200", description = "Dishes retrieved successfully"),
+                        @ApiResponse(responseCode = "400", description = "Invalid pagination parameters", content = @Content(schema = @Schema(implementation = ExceptionResponse.class))),
+                        @ApiResponse(responseCode = "500", description = "Internal server error", content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
+        })
+        @GetMapping("/restaurant/{restaurantId}")
+        public ResponseEntity<PageInfo<DishResponse>> findAllByRestaurantId(
+                        @PathVariable @Schema(description = "ID of the restaurant", example = "1") Long restaurantId,
+                        @RequestParam(required = false) @Schema(description = "Category ID filter (optional)", example = "2") Long categoryId,
+                        @RequestParam(defaultValue = "0") @Schema(description = "Page number (0-based)", example = "0") Integer page,
+                        @RequestParam(defaultValue = "10") @Schema(description = "Number of items per page", example = "10") Integer size,
+                        @RequestParam(defaultValue = "name") @Schema(description = "Field to sort by", example = "name") String sortBy,
+                        @RequestParam(defaultValue = "true") @Schema(description = "Sort in ascending order", example = "true") boolean orderAsc) {
+                return ResponseEntity.ok(dishHandler.findAllByRestaurantId(restaurantId, categoryId, page, size, sortBy,
+                                orderAsc));
         }
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/entities/CategoryEntity.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/entities/CategoryEntity.java
@@ -1,0 +1,29 @@
+package com.plazoleta.foodcourtmicroservice.infrastructure.entities;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "categories")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CategoryEntity {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String name;
+
+    @Column(length = 255)
+    private String description;
+}

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/entities/DishEntity.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/entities/DishEntity.java
@@ -1,10 +1,19 @@
 package com.plazoleta.foodcourtmicroservice.infrastructure.entities;
 
-import jakarta.persistence.*;
+import java.math.BigDecimal;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import java.math.BigDecimal;
 
 @Entity
 @Data
@@ -29,12 +38,12 @@ public class DishEntity {
     @Column(nullable = false, length = 255)
     private String urlImage;
 
-
-    @Column(nullable = true, length = 30)
-    private Long categoryId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private CategoryEntity category;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "restaurant_id")
+    @JoinColumn(name = "restaurant_id", nullable = false)
     private RestaurantEntity restaurant;
 
     @Column(nullable = false)

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/mappers/CategoryEntityMapper.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/mappers/CategoryEntityMapper.java
@@ -1,0 +1,14 @@
+package com.plazoleta.foodcourtmicroservice.infrastructure.mappers;
+
+import org.mapstruct.Mapper;
+
+import com.plazoleta.foodcourtmicroservice.domain.model.CategoryModel;
+import com.plazoleta.foodcourtmicroservice.infrastructure.entities.CategoryEntity;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = org.mapstruct.ReportingPolicy.IGNORE)
+public interface CategoryEntityMapper {
+
+    CategoryEntity modelToEntity(CategoryModel model);
+
+    CategoryModel entityToModel(CategoryEntity entity);
+}

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/mappers/DishEntityMapper.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/mappers/DishEntityMapper.java
@@ -6,12 +6,14 @@ import org.mapstruct.Mapping;
 import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
 import com.plazoleta.foodcourtmicroservice.infrastructure.entities.DishEntity;
 
-@Mapper(componentModel = "spring", uses = RestaurantEntityMapper.class)
+@Mapper(componentModel = "spring", uses = {RestaurantEntityMapper.class, CategoryEntityMapper.class})
 public interface DishEntityMapper {
 
     @Mapping(source = "restaurant", target = "restaurant")
+    @Mapping(source = "category", target = "category")
     DishEntity modelToEntity(DishModel dishModel);
 
     @Mapping(source = "restaurant", target = "restaurant")
+    @Mapping(source = "category", target = "category")
     DishModel entityToModel(DishEntity dishEntity);
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/repositories/postgres/CategoryRepository.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/repositories/postgres/CategoryRepository.java
@@ -1,0 +1,8 @@
+package com.plazoleta.foodcourtmicroservice.infrastructure.repositories.postgres;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.plazoleta.foodcourtmicroservice.infrastructure.entities.CategoryEntity;
+
+public interface CategoryRepository extends JpaRepository<CategoryEntity, Long> {
+}

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/repositories/postgres/specifications/DishSpecifications.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/repositories/postgres/specifications/DishSpecifications.java
@@ -1,6 +1,7 @@
 package com.plazoleta.foodcourtmicroservice.infrastructure.repositories.postgres.specifications;
 
 import com.plazoleta.foodcourtmicroservice.infrastructure.entities.DishEntity;
+import com.plazoleta.foodcourtmicroservice.infrastructure.utils.constants.SpecificationConstants;
 import org.springframework.data.jpa.domain.Specification;
 
 public class DishSpecifications {
@@ -11,19 +12,27 @@ public class DishSpecifications {
 
     public static Specification<DishEntity> nameEqualsIgnoreCaseAndRestaurantId(String name, Long restaurantId) {
         return (root, query, cb) -> cb.and(
-                cb.equal(cb.lower(root.get("name")), name.toLowerCase()),
-                cb.equal(root.get("restaurant").get("id"), restaurantId));
+                cb.equal(cb.lower(root.get(SpecificationConstants.NAME_FIELD)), name.toLowerCase()),
+                cb.equal(root.get(SpecificationConstants.RESTAURANT_FIELD).get(SpecificationConstants.ID_FIELD), restaurantId));
     }
 
     public static Specification<DishEntity> idEqualsAndRestaurantId(Long dishId, Long restaurantId) {
         return (root, query, cb) -> cb.and(
-                cb.equal(root.get("id"), dishId),
-                cb.equal(root.get("restaurant").get("id"), restaurantId));
+                cb.equal(root.get(SpecificationConstants.ID_FIELD), dishId),
+                cb.equal(root.get(SpecificationConstants.RESTAURANT_FIELD).get(SpecificationConstants.ID_FIELD), restaurantId));
     }
 
     public static Specification<DishEntity> restaurantIdEqualsAndOwnerId(Long restaurantId, Long currentUserId) {
         return (root, query, cb) -> cb.and(
-                cb.equal(root.get("restaurant").get("id"), restaurantId),
-                cb.equal(root.get("restaurant").get("ownerId"), currentUserId));
+                cb.equal(root.get(SpecificationConstants.RESTAURANT_FIELD).get(SpecificationConstants.ID_FIELD), restaurantId),
+                cb.equal(root.get(SpecificationConstants.RESTAURANT_FIELD).get(SpecificationConstants.OWNER_ID_FIELD), currentUserId));
+    }
+
+    public static Specification<DishEntity> restaurantIdEquals(Long restaurantId) {
+        return (root, query, cb) -> cb.equal(root.get(SpecificationConstants.RESTAURANT_FIELD).get(SpecificationConstants.ID_FIELD), restaurantId);
+    }
+
+    public static Specification<DishEntity> categoryIdEquals(Long categoryId) {
+        return (root, query, cb) -> cb.equal(root.get(SpecificationConstants.CATEGORY_ID_FIELD), categoryId);
     }
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/repositories/postgres/specifications/DishSpecifications.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/repositories/postgres/specifications/DishSpecifications.java
@@ -33,6 +33,6 @@ public class DishSpecifications {
     }
 
     public static Specification<DishEntity> categoryIdEquals(Long categoryId) {
-        return (root, query, cb) -> cb.equal(root.get(SpecificationConstants.CATEGORY_ID_FIELD), categoryId);
+        return (root, query, cb) -> cb.equal(root.get(SpecificationConstants.CATEGORY_FIELD).get(SpecificationConstants.ID_FIELD), categoryId);
     }
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/security/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
                     http.requestMatchers(HttpMethod.POST, "/api/v1/dish/").hasAuthority("OWNER");
                     http.requestMatchers(HttpMethod.PATCH, "/api/v1/dish/{id}").hasAuthority("OWNER");
                     http.requestMatchers(HttpMethod.PATCH, "/api/v1/dish/{id}/active").hasAuthority("OWNER");
+                    http.requestMatchers(HttpMethod.GET, "/api/v1/dish/restaurant/{restaurantId}").hasAuthority("CUSTOMER");
 
                     http.anyRequest().denyAll();
                 })

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/utils/constants/SpecificationConstants.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/utils/constants/SpecificationConstants.java
@@ -8,6 +8,7 @@ public final class SpecificationConstants {
     public static final String NAME_FIELD = "name";
     public static final String OWNER_ID_FIELD = "ownerId";
     public static final String CATEGORY_ID_FIELD = "categoryId";
+    public static final String CATEGORY_FIELD = "category";
 
     private SpecificationConstants() {
         throw new IllegalStateException("Utility class");

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/utils/constants/SpecificationConstants.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/utils/constants/SpecificationConstants.java
@@ -1,0 +1,15 @@
+package com.plazoleta.foodcourtmicroservice.infrastructure.utils.constants;
+
+public final class SpecificationConstants {
+
+    // Entity field names
+    public static final String RESTAURANT_FIELD = "restaurant";
+    public static final String ID_FIELD = "id";
+    public static final String NAME_FIELD = "name";
+    public static final String OWNER_ID_FIELD = "ownerId";
+    public static final String CATEGORY_ID_FIELD = "categoryId";
+
+    private SpecificationConstants() {
+        throw new IllegalStateException("Utility class");
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,10 @@ spring:
     properties:
       hibernate:
         format_sql: true
+  sql:
+    init:
+      mode: always
+
 jwt:
   secret: ${JWT_SECRET}
   user: ${JWT_USER:AUTH0JWT_BACKEND}
@@ -22,9 +26,9 @@ jwt:
   
   # Uncomment the following lines to enable debug logging
 
-logging:
- level:
-   root: debug
+# logging:
+#  level:
+#    root: debug
 
 user-microservice:
   url: http://localhost:8091

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,23 @@
+-- Sample data for foodcourt-microservice (restaurants, categories, dishes)
+
+-- Categories
+INSERT INTO categories (id, name, description) VALUES (1, 'Burgers', 'All types of burgers') ON CONFLICT (id) DO NOTHING;
+INSERT INTO categories (id, name, description) VALUES (2, 'Pizzas', 'Delicious pizzas') ON CONFLICT (id) DO NOTHING;
+INSERT INTO categories (id, name, description) VALUES (3, 'Drinks', 'Beverages and soft drinks') ON CONFLICT (id) DO NOTHING;
+INSERT INTO categories (id, name, description) VALUES (4, 'Desserts', 'Sweet desserts') ON CONFLICT (id) DO NOTHING;
+
+-- Restaurants
+INSERT INTO restaurants (id, name, nit, address, phone_number, url_logo, owner_id) VALUES (1, 'Burger House', '900123456', 'Main St 123', '+573001234567', 'https://cdn.example.com/logo/burgerhouse.png', 1) ON CONFLICT (id) DO NOTHING;
+INSERT INTO restaurants (id, name, nit, address, phone_number, url_logo, owner_id) VALUES (2, 'Pizza World', '900654321', '2nd Ave 45', '+573002345678', 'https://cdn.example.com/logo/pizzaworld.png', 2) ON CONFLICT (id) DO NOTHING;
+
+-- Dishes (10 examples, various categories/restaurants)
+INSERT INTO dishes (id, name, price, description, url_image, category_id, restaurant_id, active) VALUES (1, 'Classic Burger', 15000, 'Juicy beef burger with cheddar cheese', 'https://cdn.example.com/img/burger1.jpg', 1, 1, true) ON CONFLICT (id) DO NOTHING;
+INSERT INTO dishes (id, name, price, description, url_image, category_id, restaurant_id, active) VALUES (2, 'Double Burger', 18000, 'Double beef, double cheese', 'https://cdn.example.com/img/burger2.jpg', 1, 1, true) ON CONFLICT (id) DO NOTHING;
+INSERT INTO dishes (id, name, price, description, url_image, category_id, restaurant_id, active) VALUES (3, 'Veggie Burger', 14000, 'Vegetarian burger with fresh veggies', 'https://cdn.example.com/img/burger3.jpg', 1, 1, true) ON CONFLICT (id) DO NOTHING;
+INSERT INTO dishes (id, name, price, description, url_image, category_id, restaurant_id, active) VALUES (4, 'Pepperoni Pizza', 22000, 'Classic pepperoni pizza', 'https://cdn.example.com/img/pizza1.jpg', 2, 2, true) ON CONFLICT (id) DO NOTHING;
+INSERT INTO dishes (id, name, price, description, url_image, category_id, restaurant_id, active) VALUES (5, 'Hawaiian Pizza', 21000, 'Pizza with ham and pineapple', 'https://cdn.example.com/img/pizza2.jpg', 2, 2, true) ON CONFLICT (id) DO NOTHING;
+INSERT INTO dishes (id, name, price, description, url_image, category_id, restaurant_id, active) VALUES (6, 'Margherita Pizza', 20000, 'Classic margherita with mozzarella', 'https://cdn.example.com/img/pizza3.jpg', 2, 2, true) ON CONFLICT (id) DO NOTHING;
+INSERT INTO dishes (id, name, price, description, url_image, category_id, restaurant_id, active) VALUES (7, 'Coke', 5000, 'Cold Coca-Cola', 'https://cdn.example.com/img/coke.jpg', 3, 1, true) ON CONFLICT (id) DO NOTHING;
+INSERT INTO dishes (id, name, price, description, url_image, category_id, restaurant_id, active) VALUES (8, 'Lemonade', 4500, 'Fresh lemonade', 'https://cdn.example.com/img/lemonade.jpg', 3, 2, true) ON CONFLICT (id) DO NOTHING;
+INSERT INTO dishes (id, name, price, description, url_image, category_id, restaurant_id, active) VALUES (9, 'Brownie', 7000, 'Chocolate brownie with ice cream', 'https://cdn.example.com/img/brownie.jpg', 4, 1, true) ON CONFLICT (id) DO NOTHING;
+INSERT INTO dishes (id, name, price, description, url_image, category_id, restaurant_id, active) VALUES (10, 'Cheesecake', 7500, 'Classic cheesecake', 'https://cdn.example.com/img/cheesecake.jpg', 4, 1, true) ON CONFLICT (id) DO NOTHING;

--- a/src/test/java/com/plazoleta/foodcourtmicroservice/domain/model/DishModelTest.java
+++ b/src/test/java/com/plazoleta/foodcourtmicroservice/domain/model/DishModelTest.java
@@ -15,15 +15,19 @@ class DishModelTest {
         return new RestaurantModel(id, "Restaurante Prueba", "NIT123", "Calle 1", "123456789", "https://logo.com/logo.jpg", 1L);
     }
 
+    private CategoryModel buildCategory(Long id) {
+        return new CategoryModel(id, "cat", "desc");
+    }
+
     @Test
     void when_createDishModelWithAllFields_then_fieldsAreSetCorrectly() {
-        DishModel dish = new DishModel(1L, "Pizza", new BigDecimal("10000"), "desc", "url", 2L, buildRestaurant(10L), true);
+        DishModel dish = new DishModel(1L, "Pizza", new BigDecimal("10000"), "desc", "url", buildCategory(2L), buildRestaurant(10L), true);
         assertEquals(1L, dish.getId());
         assertEquals("Pizza", dish.getName());
         assertEquals(new BigDecimal("10000"), dish.getPrice());
         assertEquals("desc", dish.getDescription());
         assertEquals("url", dish.getUrlImage());
-        assertEquals(2L, dish.getCategoryId());
+        assertEquals(2L, dish.getCategory().getId());
         assertEquals(10L, dish.getRestaurant().getId());
         assertTrue(dish.getActive());
     }
@@ -36,7 +40,7 @@ class DishModelTest {
         dish.setPrice(new BigDecimal("5000"));
         dish.setDescription("desc2");
         dish.setUrlImage("img");
-        dish.setCategoryId(3L);
+        dish.setCategory(buildCategory(3L));
         dish.setRestaurant(buildRestaurant(11L));
         dish.setActive(false);
         assertEquals(2L, dish.getId());
@@ -44,16 +48,16 @@ class DishModelTest {
         assertEquals(new BigDecimal("5000"), dish.getPrice());
         assertEquals("desc2", dish.getDescription());
         assertEquals("img", dish.getUrlImage());
-        assertEquals(3L, dish.getCategoryId());
+        assertEquals(3L, dish.getCategory().getId());
         assertEquals(11L, dish.getRestaurant().getId());
         assertFalse(dish.getActive());
     }
 
     @Test
     void when_equalsAndHashCode_then_worksById() {
-        DishModel d1 = new DishModel(1L, "Pizza", new BigDecimal("10000"), "desc", "url", 2L, buildRestaurant(10L), true);
-        DishModel d2 = new DishModel(1L, "Other", new BigDecimal("20000"), "desc2", "url2", 3L, buildRestaurant(11L), false);
-        DishModel d3 = new DishModel(2L, "Pizza", new BigDecimal("10000"), "desc", "url", 2L, buildRestaurant(10L), true);
+        DishModel d1 = new DishModel(1L, "Pizza", new BigDecimal("10000"), "desc", "url", buildCategory(2L), buildRestaurant(10L), true);
+        DishModel d2 = new DishModel(1L, "Other", new BigDecimal("20000"), "desc2", "url2", buildCategory(3L), buildRestaurant(11L), false);
+        DishModel d3 = new DishModel(2L, "Pizza", new BigDecimal("10000"), "desc", "url", buildCategory(2L), buildRestaurant(10L), true);
         assertEquals(d1, d2);
         assertNotEquals(d1, d3);
         assertEquals(d1.hashCode(), d2.hashCode());
@@ -62,7 +66,7 @@ class DishModelTest {
 
     @Test
     void when_toString_then_containsAllFields() {
-        DishModel dish = new DishModel(1L, "Pizza", new BigDecimal("10000"), "desc", "url", 2L, buildRestaurant(10L), true);
+        DishModel dish = new DishModel(1L, "Pizza", new BigDecimal("10000"), "desc", "url", buildCategory(2L), buildRestaurant(10L), true);
         String str = dish.toString();
         assertTrue(str.contains("Pizza"));
         assertTrue(str.contains("10000"));

--- a/src/test/java/com/plazoleta/foodcourtmicroservice/domain/usecases/DishUseCaseTest.java
+++ b/src/test/java/com/plazoleta/foodcourtmicroservice/domain/usecases/DishUseCaseTest.java
@@ -1,3 +1,4 @@
+// ...existing code...
 package com.plazoleta.foodcourtmicroservice.domain.usecases;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -30,356 +31,384 @@ import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
 import com.plazoleta.foodcourtmicroservice.domain.model.RestaurantModel;
 import com.plazoleta.foodcourtmicroservice.domain.ports.out.AuthenticatedUserPort;
 import com.plazoleta.foodcourtmicroservice.domain.ports.out.DishPersistencePort;
-import com.plazoleta.foodcourtmicroservice.domain.utils.constants.DomainMessagesConstants;
 import com.plazoleta.foodcourtmicroservice.domain.ports.out.RestaurantPersistencePort;
+import com.plazoleta.foodcourtmicroservice.domain.utils.constants.DomainMessagesConstants;
 import com.plazoleta.foodcourtmicroservice.domain.validation.dish.DishValidatorChain;
 import com.plazoleta.foodcourtmicroservice.domain.validation.pagination.PaginationValidatorChain;
 
 class DishUseCaseTest {
 
-    private RestaurantModel buildRestaurant(Long id) {
-        return new RestaurantModel(id, "Restaurante Prueba", "NIT123", "Calle 1", "123456789",
-                "https://logo.com/logo.jpg", 1L);
-    }
+        private RestaurantModel buildRestaurant(Long id) {
+                return new RestaurantModel(id, "Restaurante Prueba", "NIT123", "Calle 1", "123456789",
+                                "https://logo.com/logo.jpg", 1L);
+        }
 
+        @Mock
+        private DishPersistencePort persistencePort;
 
-    @Mock
-    private DishPersistencePort persistencePort;
+        @Mock
+        private DishValidatorChain validatorChain;
 
-    @Mock
-    private DishValidatorChain validatorChain;
+        @Mock
+        private AuthenticatedUserPort authenticatedUserPort;
 
-    @Mock
-    private AuthenticatedUserPort authenticatedUserPort;
+        @Mock
+        private PaginationValidatorChain paginationValidatorChain;
 
-    @Mock
-    private PaginationValidatorChain paginationValidatorChain;
+        @Mock
+        private RestaurantPersistencePort restaurantPersistencePort;
 
-    @Mock
-    private RestaurantPersistencePort restaurantPersistencePort;
+        @InjectMocks
+        private DishUseCase useCase;
 
-    @InjectMocks
-    private DishUseCase useCase;
+        private DishModel model;
 
-    private DishModel model;
+        @BeforeEach
+        void setUp() {
+                MockitoAnnotations.openMocks(this);
+                model = new DishModel(1L, "Hamburguesa", new BigDecimal("15000.00"), "Clásica hamburguesa",
+                                "https://img.com/hamburguesa.jpg", 2L, buildRestaurant(10L), true);
+                useCase = new DishUseCase(persistencePort, validatorChain, authenticatedUserPort,
+                                paginationValidatorChain, restaurantPersistencePort);
+        }
 
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-        model = new DishModel(1L, "Hamburguesa", new BigDecimal("15000.00"), "Clásica hamburguesa",
-                "https://img.com/hamburguesa.jpg", 2L, buildRestaurant(10L), true);
-        useCase = new DishUseCase(persistencePort, validatorChain, authenticatedUserPort, paginationValidatorChain, restaurantPersistencePort);
-    }
+        @Test
+        void when_setDishActive_userNotOwnerRole_then_throwUnauthorizedOperationException() {
+                // Arrange
+                Long dishId = 1L;
+                Long restaurantId = 10L;
+                boolean active = true;
+                when(authenticatedUserPort.getCurrentUserRoles()).thenReturn(Arrays.asList("EMPLOYEE"));
 
-    @Test
-    void when_setDishActive_userNotOwnerRole_then_throwUnauthorizedOperationException() {
-        // Arrange
-        Long dishId = 1L;
-        Long restaurantId = 10L;
-        boolean active = true;
-        when(authenticatedUserPort.getCurrentUserRoles()).thenReturn(Arrays.asList("EMPLOYEE"));
+                // Act & Assert
+                UnauthorizedOperationException ex = assertThrows(
+                                UnauthorizedOperationException.class,
+                                () -> useCase.setDishActive(dishId, restaurantId, active));
+                assertEquals(
+                                DomainMessagesConstants.USER_NOT_AUTHORIZED_TO_ENABLE_DISABLE_DISH,
+                                ex.getMessage());
+                verify(authenticatedUserPort, times(1)).getCurrentUserRoles();
+                verify(authenticatedUserPort, never()).getCurrentUserId();
+                verify(persistencePort, never()).existsByRestaurantIdAndOwnerId(anyLong(), anyLong());
+                verify(persistencePort, never()).existsByIdAndRestaurantId(anyLong(), anyLong());
+                verify(persistencePort, never()).setDishActive(anyLong(), anyLong(), anyBoolean());
+        }
 
-        // Act & Assert
-        UnauthorizedOperationException ex = assertThrows(
-                UnauthorizedOperationException.class,
-                () -> useCase.setDishActive(dishId, restaurantId, active));
-        assertEquals(
-                DomainMessagesConstants.USER_NOT_AUTHORIZED_TO_ENABLE_DISABLE_DISH,
-                ex.getMessage());
-        verify(authenticatedUserPort, times(1)).getCurrentUserRoles();
-        verify(authenticatedUserPort, never()).getCurrentUserId();
-        verify(persistencePort, never()).existsByRestaurantIdAndOwnerId(anyLong(), anyLong());
-        verify(persistencePort, never()).existsByIdAndRestaurantId(anyLong(), anyLong());
-        verify(persistencePort, never()).setDishActive(anyLong(), anyLong(), anyBoolean());
-    }
+        @Test
+        void when_setDishActive_userNotOwnerOfRestaurant_then_throwUnauthorizedOperationException() {
+                // Arrange
+                Long dishId = 1L;
+                Long restaurantId = 10L;
+                boolean active = false;
+                when(authenticatedUserPort.getCurrentUserRoles()).thenReturn(Arrays.asList("OWNER"));
+                when(authenticatedUserPort.getCurrentUserId()).thenReturn(99L);
+                when(persistencePort.existsByRestaurantIdAndOwnerId(restaurantId, 99L)).thenReturn(false);
 
-    @Test
-    void when_setDishActive_userNotOwnerOfRestaurant_then_throwUnauthorizedOperationException() {
-        // Arrange
-        Long dishId = 1L;
-        Long restaurantId = 10L;
-        boolean active = false;
-        when(authenticatedUserPort.getCurrentUserRoles()).thenReturn(Arrays.asList("OWNER"));
-        when(authenticatedUserPort.getCurrentUserId()).thenReturn(99L);
-        when(persistencePort.existsByRestaurantIdAndOwnerId(restaurantId, 99L)).thenReturn(false);
+                // Act & Assert
+                UnauthorizedOperationException ex = assertThrows(
+                                UnauthorizedOperationException.class,
+                                () -> useCase.setDishActive(dishId, restaurantId, active));
+                assertEquals(
+                                DomainMessagesConstants.USER_NOT_OWNER_OF_RESTAURANT,
+                                ex.getMessage());
+                verify(authenticatedUserPort, times(1)).getCurrentUserRoles();
+                verify(authenticatedUserPort, times(1)).getCurrentUserId();
+                verify(persistencePort, times(1)).existsByRestaurantIdAndOwnerId(restaurantId, 99L);
+                verify(persistencePort, never()).existsByIdAndRestaurantId(anyLong(), anyLong());
+                verify(persistencePort, never()).setDishActive(anyLong(), anyLong(), anyBoolean());
+        }
 
-        // Act & Assert
-        UnauthorizedOperationException ex = assertThrows(
-                UnauthorizedOperationException.class,
-                () -> useCase.setDishActive(dishId, restaurantId, active));
-        assertEquals(
-                DomainMessagesConstants.USER_NOT_OWNER_OF_RESTAURANT,
-                ex.getMessage());
-        verify(authenticatedUserPort, times(1)).getCurrentUserRoles();
-        verify(authenticatedUserPort, times(1)).getCurrentUserId();
-        verify(persistencePort, times(1)).existsByRestaurantIdAndOwnerId(restaurantId, 99L);
-        verify(persistencePort, never()).existsByIdAndRestaurantId(anyLong(), anyLong());
-        verify(persistencePort, never()).setDishActive(anyLong(), anyLong(), anyBoolean());
-    }
+        @Test
+        void when_setDishActive_dishNotFound_then_throwElementNotFoundException() {
+                // Arrange
+                Long dishId = 1L;
+                Long restaurantId = 10L;
+                boolean active = false;
+                when(authenticatedUserPort.getCurrentUserRoles()).thenReturn(Arrays.asList("OWNER"));
+                when(authenticatedUserPort.getCurrentUserId()).thenReturn(1L);
+                when(persistencePort.existsByRestaurantIdAndOwnerId(restaurantId, 1L)).thenReturn(true);
+                when(persistencePort.existsByIdAndRestaurantId(dishId, restaurantId)).thenReturn(false);
 
-    @Test
-    void when_setDishActive_dishNotFound_then_throwElementNotFoundException() {
-        // Arrange
-        Long dishId = 1L;
-        Long restaurantId = 10L;
-        boolean active = false;
-        when(authenticatedUserPort.getCurrentUserRoles()).thenReturn(Arrays.asList("OWNER"));
-        when(authenticatedUserPort.getCurrentUserId()).thenReturn(1L);
-        when(persistencePort.existsByRestaurantIdAndOwnerId(restaurantId, 1L)).thenReturn(true);
-        when(persistencePort.existsByIdAndRestaurantId(dishId, restaurantId)).thenReturn(false);
+                // Act & Assert
+                ElementNotFoundException ex = assertThrows(
+                                ElementNotFoundException.class,
+                                () -> useCase.setDishActive(dishId, restaurantId, active));
+                assertEquals(String.format(
+                                DomainMessagesConstants.DISH_NOT_FOUND_IN_RESTAURANT,
+                                dishId, restaurantId), ex.getMessage());
+                verify(authenticatedUserPort, times(1)).getCurrentUserRoles();
+                verify(authenticatedUserPort, times(1)).getCurrentUserId();
+                verify(persistencePort, times(1)).existsByRestaurantIdAndOwnerId(restaurantId, 1L);
+                verify(persistencePort, times(1)).existsByIdAndRestaurantId(dishId, restaurantId);
+                verify(persistencePort, never()).setDishActive(anyLong(), anyLong(), anyBoolean());
+        }
 
-        // Act & Assert
-        ElementNotFoundException ex = assertThrows(
-                ElementNotFoundException.class,
-                () -> useCase.setDishActive(dishId, restaurantId, active));
-        assertEquals(String.format(
-                DomainMessagesConstants.DISH_NOT_FOUND_IN_RESTAURANT,
-                dishId, restaurantId), ex.getMessage());
-        verify(authenticatedUserPort, times(1)).getCurrentUserRoles();
-        verify(authenticatedUserPort, times(1)).getCurrentUserId();
-        verify(persistencePort, times(1)).existsByRestaurantIdAndOwnerId(restaurantId, 1L);
-        verify(persistencePort, times(1)).existsByIdAndRestaurantId(dishId, restaurantId);
-        verify(persistencePort, never()).setDishActive(anyLong(), anyLong(), anyBoolean());
-    }
+        @Test
+        void when_setDishActive_validRequest_then_setDishActiveCalled() {
+                // Arrange
+                Long dishId = 1L;
+                Long restaurantId = 10L;
+                boolean active = true;
+                when(authenticatedUserPort.getCurrentUserRoles()).thenReturn(Arrays.asList("OWNER"));
+                when(authenticatedUserPort.getCurrentUserId()).thenReturn(1L);
+                when(persistencePort.existsByRestaurantIdAndOwnerId(restaurantId, 1L)).thenReturn(true);
+                when(persistencePort.existsByIdAndRestaurantId(dishId, restaurantId)).thenReturn(true);
 
-    @Test
-    void when_setDishActive_validRequest_then_setDishActiveCalled() {
-        // Arrange
-        Long dishId = 1L;
-        Long restaurantId = 10L;
-        boolean active = true;
-        when(authenticatedUserPort.getCurrentUserRoles()).thenReturn(Arrays.asList("OWNER"));
-        when(authenticatedUserPort.getCurrentUserId()).thenReturn(1L);
-        when(persistencePort.existsByRestaurantIdAndOwnerId(restaurantId, 1L)).thenReturn(true);
-        when(persistencePort.existsByIdAndRestaurantId(dishId, restaurantId)).thenReturn(true);
+                // Act
+                useCase.setDishActive(dishId, restaurantId, active);
 
-        // Act
-        useCase.setDishActive(dishId, restaurantId, active);
+                // Assert
+                verify(authenticatedUserPort, times(1)).getCurrentUserRoles();
+                verify(authenticatedUserPort, times(1)).getCurrentUserId();
+                verify(persistencePort, times(1)).existsByRestaurantIdAndOwnerId(restaurantId, 1L);
+                verify(persistencePort, times(1)).existsByIdAndRestaurantId(dishId, restaurantId);
+                verify(persistencePort, times(1)).setDishActive(dishId, restaurantId, active);
+        }
 
-        // Assert
-        verify(authenticatedUserPort, times(1)).getCurrentUserRoles();
-        verify(authenticatedUserPort, times(1)).getCurrentUserId();
-        verify(persistencePort, times(1)).existsByRestaurantIdAndOwnerId(restaurantId, 1L);
-        verify(persistencePort, times(1)).existsByIdAndRestaurantId(dishId, restaurantId);
-        verify(persistencePort, times(1)).setDishActive(dishId, restaurantId, active);
-    }
+        @Test
+        void when_save_withValidDishAndOwnerOfRestaurant_then_dishIsSaved() {
+                // Arrange
+                when(authenticatedUserPort.getCurrentUserRoles()).thenReturn(Collections.singletonList("OWNER"));
+                when(authenticatedUserPort.getCurrentUserId()).thenReturn(1L);
+                when(persistencePort.existsByRestaurantIdAndOwnerId(model.getRestaurant().getId(), 1L))
+                                .thenReturn(true);
+                when(persistencePort.existsByNameAndRestaurantId(model.getName(), model.getRestaurant().getId()))
+                                .thenReturn(false);
 
-    @Test
-    void when_save_withValidDishAndOwnerOfRestaurant_then_dishIsSaved() {
-        // Arrange
-        when(authenticatedUserPort.getCurrentUserRoles()).thenReturn(Collections.singletonList("OWNER"));
-        when(authenticatedUserPort.getCurrentUserId()).thenReturn(1L);
-        when(persistencePort.existsByRestaurantIdAndOwnerId(model.getRestaurant().getId(), 1L)).thenReturn(true);
-        when(persistencePort.existsByNameAndRestaurantId(model.getName(), model.getRestaurant().getId()))
-                .thenReturn(false);
+                // Act
+                useCase.save(model);
 
-        // Act
-        useCase.save(model);
+                // Assert
+                verify(authenticatedUserPort, times(1)).getCurrentUserRoles();
+                verify(authenticatedUserPort, times(1)).getCurrentUserId();
+                verify(persistencePort, times(1)).existsByRestaurantIdAndOwnerId(model.getRestaurant().getId(), 1L);
+                verify(validatorChain, times(1)).validate(model, OperationType.CREATE);
+                verify(persistencePort, times(1)).existsByNameAndRestaurantId(model.getName(),
+                                model.getRestaurant().getId());
+                verify(persistencePort, times(1)).save(model);
+        }
 
-        // Assert
-        verify(authenticatedUserPort, times(1)).getCurrentUserRoles();
-        verify(authenticatedUserPort, times(1)).getCurrentUserId();
-        verify(persistencePort, times(1)).existsByRestaurantIdAndOwnerId(model.getRestaurant().getId(), 1L);
-        verify(validatorChain, times(1)).validate(model, OperationType.CREATE);
-        verify(persistencePort, times(1)).existsByNameAndRestaurantId(model.getName(), model.getRestaurant().getId());
-        verify(persistencePort, times(1)).save(model);
-    }
+        @Test
+        void when_save_withOwnerRoleButNotOwnerOfRestaurant_then_throwUnauthorizedOperationException() {
+                // Arrange
+                when(authenticatedUserPort.getCurrentUserRoles()).thenReturn(Collections.singletonList("OWNER"));
+                when(authenticatedUserPort.getCurrentUserId()).thenReturn(2L);
+                when(persistencePort.existsByRestaurantIdAndOwnerId(model.getRestaurant().getId(), 2L))
+                                .thenReturn(false);
 
-    @Test
-    void when_save_withOwnerRoleButNotOwnerOfRestaurant_then_throwUnauthorizedOperationException() {
-        // Arrange
-        when(authenticatedUserPort.getCurrentUserRoles()).thenReturn(Collections.singletonList("OWNER"));
-        when(authenticatedUserPort.getCurrentUserId()).thenReturn(2L);
-        when(persistencePort.existsByRestaurantIdAndOwnerId(model.getRestaurant().getId(), 2L)).thenReturn(false);
+                // Act & Assert
+                UnauthorizedOperationException ex = assertThrows(UnauthorizedOperationException.class,
+                                () -> useCase.save(model));
+                assertEquals(DomainMessagesConstants.USER_NOT_OWNER_OF_RESTAURANT, ex.getMessage());
+                verify(authenticatedUserPort, times(1)).getCurrentUserRoles();
+                verify(authenticatedUserPort, times(1)).getCurrentUserId();
+                verify(persistencePort, times(1)).existsByRestaurantIdAndOwnerId(model.getRestaurant().getId(), 2L);
+                verify(validatorChain, never()).validate(any(), any());
+                verify(persistencePort, never()).existsByNameAndRestaurantId(any(), anyLong());
+                verify(persistencePort, never()).save(any());
+        }
 
-        // Act & Assert
-        UnauthorizedOperationException ex = assertThrows(UnauthorizedOperationException.class,
-                () -> useCase.save(model));
-        assertEquals(DomainMessagesConstants.USER_NOT_OWNER_OF_RESTAURANT, ex.getMessage());
-        verify(authenticatedUserPort, times(1)).getCurrentUserRoles();
-        verify(authenticatedUserPort, times(1)).getCurrentUserId();
-        verify(persistencePort, times(1)).existsByRestaurantIdAndOwnerId(model.getRestaurant().getId(), 2L);
-        verify(validatorChain, never()).validate(any(), any());
-        verify(persistencePort, never()).existsByNameAndRestaurantId(any(), anyLong());
-        verify(persistencePort, never()).save(any());
-    }
+        @Test
+        void when_save_withExistingDishName_then_throwElementAlreadyExistsException() {
+                // Arrange
+                when(authenticatedUserPort.getCurrentUserRoles()).thenReturn(Collections.singletonList("OWNER"));
+                when(authenticatedUserPort.getCurrentUserId()).thenReturn(1L);
+                when(persistencePort.existsByRestaurantIdAndOwnerId(model.getRestaurant().getId(), 1L))
+                                .thenReturn(true);
+                when(persistencePort.existsByNameAndRestaurantId(model.getName(), model.getRestaurant().getId()))
+                                .thenReturn(true);
 
-    @Test
-    void when_save_withExistingDishName_then_throwElementAlreadyExistsException() {
-        // Arrange
-        when(authenticatedUserPort.getCurrentUserRoles()).thenReturn(Collections.singletonList("OWNER"));
-        when(authenticatedUserPort.getCurrentUserId()).thenReturn(1L);
-        when(persistencePort.existsByRestaurantIdAndOwnerId(model.getRestaurant().getId(), 1L)).thenReturn(true);
-        when(persistencePort.existsByNameAndRestaurantId(model.getName(), model.getRestaurant().getId()))
-                .thenReturn(true);
+                // Act & Assert
+                ElementAlreadyExistsException ex = assertThrows(ElementAlreadyExistsException.class,
+                                () -> useCase.save(model));
+                assertEquals(String.format(DomainMessagesConstants.DISH_ALREADY_EXISTS, model.getName()),
+                                ex.getMessage());
+                verify(authenticatedUserPort, times(1)).getCurrentUserRoles();
+                verify(authenticatedUserPort, times(1)).getCurrentUserId();
+                verify(persistencePort, times(1)).existsByRestaurantIdAndOwnerId(model.getRestaurant().getId(), 1L);
+                verify(validatorChain, times(1)).validate(model, OperationType.CREATE);
+                verify(persistencePort, times(1)).existsByNameAndRestaurantId(model.getName(),
+                                model.getRestaurant().getId());
+                verify(persistencePort, never()).save(any());
+        }
 
-        // Act & Assert
-        ElementAlreadyExistsException ex = assertThrows(ElementAlreadyExistsException.class, () -> useCase.save(model));
-        assertEquals(String.format(DomainMessagesConstants.DISH_ALREADY_EXISTS, model.getName()), ex.getMessage());
-        verify(authenticatedUserPort, times(1)).getCurrentUserRoles();
-        verify(authenticatedUserPort, times(1)).getCurrentUserId();
-        verify(persistencePort, times(1)).existsByRestaurantIdAndOwnerId(model.getRestaurant().getId(), 1L);
-        verify(validatorChain, times(1)).validate(model, OperationType.CREATE);
-        verify(persistencePort, times(1)).existsByNameAndRestaurantId(model.getName(), model.getRestaurant().getId());
-        verify(persistencePort, never()).save(any());
-    }
+        @Test
+        void when_save_withInvalidDish_then_throwValidationException() {
+                // Arrange
+                when(authenticatedUserPort.getCurrentUserRoles()).thenReturn(Collections.singletonList("OWNER"));
+                when(authenticatedUserPort.getCurrentUserId()).thenReturn(1L);
+                when(persistencePort.existsByRestaurantIdAndOwnerId(model.getRestaurant().getId(), 1L))
+                                .thenReturn(true);
+                doThrow(new RuntimeException("Validation error")).when(validatorChain).validate(model,
+                                OperationType.CREATE);
 
-    @Test
-    void when_save_withInvalidDish_then_throwValidationException() {
-        // Arrange
-        when(authenticatedUserPort.getCurrentUserRoles()).thenReturn(Collections.singletonList("OWNER"));
-        when(authenticatedUserPort.getCurrentUserId()).thenReturn(1L);
-        when(persistencePort.existsByRestaurantIdAndOwnerId(model.getRestaurant().getId(), 1L)).thenReturn(true);
-        doThrow(new RuntimeException("Validation error")).when(validatorChain).validate(model, OperationType.CREATE);
+                // Act & Assert
+                RuntimeException ex = assertThrows(RuntimeException.class, () -> useCase.save(model));
+                assertEquals("Validation error", ex.getMessage());
+                verify(authenticatedUserPort, times(1)).getCurrentUserRoles();
+                verify(authenticatedUserPort, times(1)).getCurrentUserId();
+                verify(persistencePort, times(1)).existsByRestaurantIdAndOwnerId(model.getRestaurant().getId(), 1L);
+                verify(validatorChain, times(1)).validate(model, OperationType.CREATE);
+                verify(persistencePort, never()).existsByNameAndRestaurantId(any(), anyLong());
+                verify(persistencePort, never()).save(any());
+        }
 
-        // Act & Assert
-        RuntimeException ex = assertThrows(RuntimeException.class, () -> useCase.save(model));
-        assertEquals("Validation error", ex.getMessage());
-        verify(authenticatedUserPort, times(1)).getCurrentUserRoles();
-        verify(authenticatedUserPort, times(1)).getCurrentUserId();
-        verify(persistencePort, times(1)).existsByRestaurantIdAndOwnerId(model.getRestaurant().getId(), 1L);
-        verify(validatorChain, times(1)).validate(model, OperationType.CREATE);
-        verify(persistencePort, never()).existsByNameAndRestaurantId(any(), anyLong());
-        verify(persistencePort, never()).save(any());
-    }
+        @Test
+        void when_save_withNonOwnerRole_then_throwElementNotFoundException() {
+                // Arrange
+                when(authenticatedUserPort.getCurrentUserRoles()).thenReturn(Collections.singletonList("EMPLOYEE"));
 
-    @Test
-    void when_save_withNonOwnerRole_then_throwElementNotFoundException() {
-        // Arrange
-        when(authenticatedUserPort.getCurrentUserRoles()).thenReturn(Collections.singletonList("EMPLOYEE"));
+                // Act & Assert
+                ElementNotFoundException ex = assertThrows(ElementNotFoundException.class, () -> useCase.save(model));
+                assertEquals(DomainMessagesConstants.USER_NOT_AUTHORIZED_TO_CREATE_DISH, ex.getMessage());
+                verify(authenticatedUserPort, times(1)).getCurrentUserRoles();
+                verify(validatorChain, never()).validate(any(), any());
+                verify(persistencePort, never()).existsByNameAndRestaurantId(any(), anyLong());
+                verify(persistencePort, never()).save(any());
+        }
 
-        // Act & Assert
-        ElementNotFoundException ex = assertThrows(ElementNotFoundException.class, () -> useCase.save(model));
-        assertEquals(DomainMessagesConstants.USER_NOT_AUTHORIZED_TO_CREATE_DISH, ex.getMessage());
-        verify(authenticatedUserPort, times(1)).getCurrentUserRoles();
-        verify(validatorChain, never()).validate(any(), any());
-        verify(persistencePort, never()).existsByNameAndRestaurantId(any(), anyLong());
-        verify(persistencePort, never()).save(any());
-    }
+        @Test
 
-    @Test
+        void when_updateDish_withValidData_then_dishIsUpdated() {
+                // Arrange
+                Long dishId = 1L;
+                Long restaurantId = 10L;
+                BigDecimal price = new BigDecimal("20000.00");
+                String description = "Nueva descripción";
+                when(authenticatedUserPort.getCurrentUserRoles())
+                                .thenReturn(Collections.singletonList(DomainMessagesConstants.OWNER_ROLE));
+                when(authenticatedUserPort.getCurrentUserId()).thenReturn(1L);
+                when(persistencePort.existsByRestaurantIdAndOwnerId(restaurantId, 1L)).thenReturn(true);
+                when(persistencePort.existsByIdAndRestaurantId(dishId, restaurantId)).thenReturn(true);
 
-    void when_updateDish_withValidData_then_dishIsUpdated() {
-        // Arrange
-        Long dishId = 1L;
-        Long restaurantId = 10L;
-        BigDecimal price = new BigDecimal("20000.00");
-        String description = "Nueva descripción";
-        when(authenticatedUserPort.getCurrentUserRoles())
-                .thenReturn(Collections.singletonList(DomainMessagesConstants.OWNER_ROLE));
-        when(authenticatedUserPort.getCurrentUserId()).thenReturn(1L);
-        when(persistencePort.existsByRestaurantIdAndOwnerId(restaurantId, 1L)).thenReturn(true);
-        when(persistencePort.existsByIdAndRestaurantId(dishId, restaurantId)).thenReturn(true);
+                // Act
+                useCase.updateDish(dishId, restaurantId, price, description);
 
-        // Act
-        useCase.updateDish(dishId, restaurantId, price, description);
+                // Assert
+                verify(authenticatedUserPort, times(1)).getCurrentUserRoles();
+                verify(authenticatedUserPort, times(1)).getCurrentUserId();
+                verify(persistencePort, times(1)).existsByRestaurantIdAndOwnerId(restaurantId, 1L);
+                verify(persistencePort, times(1)).existsByIdAndRestaurantId(dishId, restaurantId);
+                verify(validatorChain, times(1)).validate(any(DishModel.class), eq(OperationType.UPDATE));
+                verify(persistencePort, times(1)).updateDish(dishId, restaurantId, price, description);
+        }
 
-        // Assert
-        verify(authenticatedUserPort, times(1)).getCurrentUserRoles();
-        verify(authenticatedUserPort, times(1)).getCurrentUserId();
-        verify(persistencePort, times(1)).existsByRestaurantIdAndOwnerId(restaurantId, 1L);
-        verify(persistencePort, times(1)).existsByIdAndRestaurantId(dishId, restaurantId);
-        verify(validatorChain, times(1)).validate(any(DishModel.class), eq(OperationType.UPDATE));
-        verify(persistencePort, times(1)).updateDish(dishId, restaurantId, price, description);
-    }
+        @Test
 
-    @Test
+        void when_updateDish_dishNotFound_then_throwElementNotFoundException() {
+                // Arrange
+                Long dishId = 1L;
+                Long restaurantId = 10L;
+                BigDecimal price = new BigDecimal("20000.00");
+                String description = "Nueva descripción";
+                when(authenticatedUserPort.getCurrentUserRoles())
+                                .thenReturn(Collections.singletonList(DomainMessagesConstants.OWNER_ROLE));
+                when(authenticatedUserPort.getCurrentUserId()).thenReturn(1L);
+                when(persistencePort.existsByRestaurantIdAndOwnerId(restaurantId, 1L)).thenReturn(true);
+                when(persistencePort.existsByIdAndRestaurantId(dishId, restaurantId)).thenReturn(false);
 
-    void when_updateDish_dishNotFound_then_throwElementNotFoundException() {
-        // Arrange
-        Long dishId = 1L;
-        Long restaurantId = 10L;
-        BigDecimal price = new BigDecimal("20000.00");
-        String description = "Nueva descripción";
-        when(authenticatedUserPort.getCurrentUserRoles())
-                .thenReturn(Collections.singletonList(DomainMessagesConstants.OWNER_ROLE));
-        when(authenticatedUserPort.getCurrentUserId()).thenReturn(1L);
-        when(persistencePort.existsByRestaurantIdAndOwnerId(restaurantId, 1L)).thenReturn(true);
-        when(persistencePort.existsByIdAndRestaurantId(dishId, restaurantId)).thenReturn(false);
+                // Act & Assert
+                ElementNotFoundException ex = assertThrows(ElementNotFoundException.class,
+                                () -> useCase.updateDish(dishId, restaurantId, price, description));
+                assertEquals(String.format(DomainMessagesConstants.DISH_NOT_FOUND_IN_RESTAURANT, dishId, restaurantId),
+                                ex.getMessage());
+                verify(authenticatedUserPort, times(1)).getCurrentUserRoles();
+                verify(authenticatedUserPort, times(1)).getCurrentUserId();
+                verify(persistencePort, times(1)).existsByRestaurantIdAndOwnerId(restaurantId, 1L);
+                verify(persistencePort, times(1)).existsByIdAndRestaurantId(dishId, restaurantId);
+                verify(validatorChain, never()).validate(any(DishModel.class), any());
+                verify(persistencePort, never()).updateDish(anyLong(), anyLong(), any(), any());
+        }
 
-        // Act & Assert
-        ElementNotFoundException ex = assertThrows(ElementNotFoundException.class,
-                () -> useCase.updateDish(dishId, restaurantId, price, description));
-        assertEquals(String.format(DomainMessagesConstants.DISH_NOT_FOUND_IN_RESTAURANT, dishId, restaurantId),
-                ex.getMessage());
-        verify(authenticatedUserPort, times(1)).getCurrentUserRoles();
-        verify(authenticatedUserPort, times(1)).getCurrentUserId();
-        verify(persistencePort, times(1)).existsByRestaurantIdAndOwnerId(restaurantId, 1L);
-        verify(persistencePort, times(1)).existsByIdAndRestaurantId(dishId, restaurantId);
-        verify(validatorChain, never()).validate(any(DishModel.class), any());
-        verify(persistencePort, never()).updateDish(anyLong(), anyLong(), any(), any());
-    }
+        @Test
 
-    @Test
+        void when_updateDish_validationFails_then_throwValidationException() {
+                // Arrange
+                Long dishId = 1L;
+                Long restaurantId = 10L;
+                BigDecimal price = new BigDecimal("20000.00");
+                String description = "Nueva descripción";
+                when(authenticatedUserPort.getCurrentUserRoles())
+                                .thenReturn(Collections.singletonList(DomainMessagesConstants.OWNER_ROLE));
+                when(authenticatedUserPort.getCurrentUserId()).thenReturn(1L);
+                when(persistencePort.existsByRestaurantIdAndOwnerId(restaurantId, 1L)).thenReturn(true);
+                when(persistencePort.existsByIdAndRestaurantId(dishId, restaurantId)).thenReturn(true);
+                doThrow(new RuntimeException("Validation error")).when(validatorChain).validate(any(DishModel.class),
+                                eq(OperationType.UPDATE));
 
-    void when_updateDish_validationFails_then_throwValidationException() {
-        // Arrange
-        Long dishId = 1L;
-        Long restaurantId = 10L;
-        BigDecimal price = new BigDecimal("20000.00");
-        String description = "Nueva descripción";
-        when(authenticatedUserPort.getCurrentUserRoles())
-                .thenReturn(Collections.singletonList(DomainMessagesConstants.OWNER_ROLE));
-        when(authenticatedUserPort.getCurrentUserId()).thenReturn(1L);
-        when(persistencePort.existsByRestaurantIdAndOwnerId(restaurantId, 1L)).thenReturn(true);
-        when(persistencePort.existsByIdAndRestaurantId(dishId, restaurantId)).thenReturn(true);
-        doThrow(new RuntimeException("Validation error")).when(validatorChain).validate(any(DishModel.class),
-                eq(OperationType.UPDATE));
+                // Act & Assert
+                RuntimeException ex = assertThrows(RuntimeException.class,
+                                () -> useCase.updateDish(dishId, restaurantId, price, description));
+                assertEquals("Validation error", ex.getMessage());
+                verify(authenticatedUserPort, times(1)).getCurrentUserRoles();
+                verify(authenticatedUserPort, times(1)).getCurrentUserId();
+                verify(persistencePort, times(1)).existsByRestaurantIdAndOwnerId(restaurantId, 1L);
+                verify(persistencePort, times(1)).existsByIdAndRestaurantId(dishId, restaurantId);
+                verify(validatorChain, times(1)).validate(any(DishModel.class), eq(OperationType.UPDATE));
+                verify(persistencePort, never()).updateDish(anyLong(), anyLong(), any(), any());
+        }
 
-        // Act & Assert
-        RuntimeException ex = assertThrows(RuntimeException.class,
-                () -> useCase.updateDish(dishId, restaurantId, price, description));
-        assertEquals("Validation error", ex.getMessage());
-        verify(authenticatedUserPort, times(1)).getCurrentUserRoles();
-        verify(authenticatedUserPort, times(1)).getCurrentUserId();
-        verify(persistencePort, times(1)).existsByRestaurantIdAndOwnerId(restaurantId, 1L);
-        verify(persistencePort, times(1)).existsByIdAndRestaurantId(dishId, restaurantId);
-        verify(validatorChain, times(1)).validate(any(DishModel.class), eq(OperationType.UPDATE));
-        verify(persistencePort, never()).updateDish(anyLong(), anyLong(), any(), any());
-    }
+        @Test
+        void when_updateDish_userNotOwnerRole_then_throwUnauthorizedOperationException() {
+                // Arrange
+                Long dishId = 1L;
+                Long restaurantId = 10L;
+                BigDecimal price = new BigDecimal("20000.00");
+                String description = "Nueva descripción";
+                when(authenticatedUserPort.getCurrentUserRoles()).thenReturn(Collections.singletonList("EMPLOYEE"));
 
-    @Test
-    void when_updateDish_userNotOwnerRole_then_throwUnauthorizedOperationException() {
-        // Arrange
-        Long dishId = 1L;
-        Long restaurantId = 10L;
-        BigDecimal price = new BigDecimal("20000.00");
-        String description = "Nueva descripción";
-        when(authenticatedUserPort.getCurrentUserRoles()).thenReturn(Collections.singletonList("EMPLOYEE"));
+                // Act & Assert
+                UnauthorizedOperationException ex = assertThrows(UnauthorizedOperationException.class,
+                                () -> useCase.updateDish(dishId, restaurantId, price, description));
+                assertEquals(DomainMessagesConstants.USER_NOT_AUTHORIZED_TO_UPDATE_DISH, ex.getMessage());
+                verify(authenticatedUserPort, times(1)).getCurrentUserRoles();
+                verify(authenticatedUserPort, never()).getCurrentUserId();
+                verify(persistencePort, never()).existsByRestaurantIdAndOwnerId(anyLong(), anyLong());
+                verify(persistencePort, never()).existsByIdAndRestaurantId(anyLong(), anyLong());
+                verify(validatorChain, never()).validate(any(DishModel.class), any());
+                verify(persistencePort, never()).updateDish(anyLong(), anyLong(), any(), any());
+        }
 
-        // Act & Assert
-        UnauthorizedOperationException ex = assertThrows(UnauthorizedOperationException.class,
-                () -> useCase.updateDish(dishId, restaurantId, price, description));
-        assertEquals(DomainMessagesConstants.USER_NOT_AUTHORIZED_TO_UPDATE_DISH, ex.getMessage());
-        verify(authenticatedUserPort, times(1)).getCurrentUserRoles();
-        verify(authenticatedUserPort, never()).getCurrentUserId();
-        verify(persistencePort, never()).existsByRestaurantIdAndOwnerId(anyLong(), anyLong());
-        verify(persistencePort, never()).existsByIdAndRestaurantId(anyLong(), anyLong());
-        verify(validatorChain, never()).validate(any(DishModel.class), any());
-        verify(persistencePort, never()).updateDish(anyLong(), anyLong(), any(), any());
-    }
+        @Test
+        void when_updateDish_userNotOwnerOfRestaurant_then_throwUnauthorizedOperationException() {
+                // Arrange
+                Long dishId = 1L;
+                Long restaurantId = 10L;
+                BigDecimal price = new BigDecimal("20000.00");
+                String description = "Nueva descripción";
+                when(authenticatedUserPort.getCurrentUserRoles())
+                                .thenReturn(Collections.singletonList(DomainMessagesConstants.OWNER_ROLE));
+                when(authenticatedUserPort.getCurrentUserId()).thenReturn(99L);
+                when(persistencePort.existsByRestaurantIdAndOwnerId(restaurantId, 99L)).thenReturn(false);
 
-    @Test
-    void when_updateDish_userNotOwnerOfRestaurant_then_throwUnauthorizedOperationException() {
-        // Arrange
-        Long dishId = 1L;
-        Long restaurantId = 10L;
-        BigDecimal price = new BigDecimal("20000.00");
-        String description = "Nueva descripción";
-        when(authenticatedUserPort.getCurrentUserRoles())
-                .thenReturn(Collections.singletonList(DomainMessagesConstants.OWNER_ROLE));
-        when(authenticatedUserPort.getCurrentUserId()).thenReturn(99L);
-        when(persistencePort.existsByRestaurantIdAndOwnerId(restaurantId, 99L)).thenReturn(false);
+                // Act & Assert
+                UnauthorizedOperationException ex = assertThrows(UnauthorizedOperationException.class,
+                                () -> useCase.updateDish(dishId, restaurantId, price, description));
+                assertEquals(DomainMessagesConstants.USER_NOT_OWNER_OF_RESTAURANT, ex.getMessage());
+                verify(authenticatedUserPort, times(1)).getCurrentUserRoles();
+                verify(authenticatedUserPort, times(1)).getCurrentUserId();
+                verify(persistencePort, times(1)).existsByRestaurantIdAndOwnerId(restaurantId, 99L);
+                verify(persistencePort, never()).existsByIdAndRestaurantId(anyLong(), anyLong());
+                verify(validatorChain, never()).validate(any(DishModel.class), any());
+                verify(persistencePort, never()).updateDish(anyLong(), anyLong(), any(), any());
+        }
 
-        // Act & Assert
-        UnauthorizedOperationException ex = assertThrows(UnauthorizedOperationException.class,
-                () -> useCase.updateDish(dishId, restaurantId, price, description));
-        assertEquals(DomainMessagesConstants.USER_NOT_OWNER_OF_RESTAURANT, ex.getMessage());
-        verify(authenticatedUserPort, times(1)).getCurrentUserRoles();
-        verify(authenticatedUserPort, times(1)).getCurrentUserId();
-        verify(persistencePort, times(1)).existsByRestaurantIdAndOwnerId(restaurantId, 99L);
-        verify(persistencePort, never()).existsByIdAndRestaurantId(anyLong(), anyLong());
-        verify(validatorChain, never()).validate(any(DishModel.class), any());
-        verify(persistencePort, never()).updateDish(anyLong(), anyLong(), any(), any());
-    }
+        @Test
+        void when_findAllByRestaurantId_restaurantDoesNotExist_then_throwElementNotFoundException() {
+                // Arrange
+                Long restaurantId = 99L;
+                Long categoryId = 1L;
+                int page = 0;
+                int size = 10;
+                String sortBy = "name";
+                boolean orderAsc = true;
+                when(restaurantPersistencePort.existsById(restaurantId)).thenReturn(false);
+
+                // Act & Assert
+                ElementNotFoundException ex = assertThrows(ElementNotFoundException.class, () -> useCase
+                                .findAllByRestaurantId(restaurantId, categoryId, page, size, sortBy, orderAsc));
+                assertEquals(String.format(DomainMessagesConstants.RESTAURANT_NOT_FOUND, restaurantId),
+                                ex.getMessage());
+                verify(restaurantPersistencePort, times(1)).existsById(restaurantId);
+        }
 }

--- a/src/test/java/com/plazoleta/foodcourtmicroservice/domain/usecases/DishUseCaseTest.java
+++ b/src/test/java/com/plazoleta/foodcourtmicroservice/domain/usecases/DishUseCaseTest.java
@@ -31,6 +31,7 @@ import com.plazoleta.foodcourtmicroservice.domain.model.RestaurantModel;
 import com.plazoleta.foodcourtmicroservice.domain.ports.out.AuthenticatedUserPort;
 import com.plazoleta.foodcourtmicroservice.domain.ports.out.DishPersistencePort;
 import com.plazoleta.foodcourtmicroservice.domain.utils.constants.DomainMessagesConstants;
+import com.plazoleta.foodcourtmicroservice.domain.ports.out.RestaurantPersistencePort;
 import com.plazoleta.foodcourtmicroservice.domain.validation.dish.DishValidatorChain;
 import com.plazoleta.foodcourtmicroservice.domain.validation.pagination.PaginationValidatorChain;
 
@@ -40,6 +41,7 @@ class DishUseCaseTest {
         return new RestaurantModel(id, "Restaurante Prueba", "NIT123", "Calle 1", "123456789",
                 "https://logo.com/logo.jpg", 1L);
     }
+
 
     @Mock
     private DishPersistencePort persistencePort;
@@ -53,6 +55,9 @@ class DishUseCaseTest {
     @Mock
     private PaginationValidatorChain paginationValidatorChain;
 
+    @Mock
+    private RestaurantPersistencePort restaurantPersistencePort;
+
     @InjectMocks
     private DishUseCase useCase;
 
@@ -63,7 +68,7 @@ class DishUseCaseTest {
         MockitoAnnotations.openMocks(this);
         model = new DishModel(1L, "Hamburguesa", new BigDecimal("15000.00"), "Clásica hamburguesa",
                 "https://img.com/hamburguesa.jpg", 2L, buildRestaurant(10L), true);
-        useCase = new DishUseCase(persistencePort, validatorChain, authenticatedUserPort, paginationValidatorChain);
+        useCase = new DishUseCase(persistencePort, validatorChain, authenticatedUserPort, paginationValidatorChain, restaurantPersistencePort);
     }
 
     @Test

--- a/src/test/java/com/plazoleta/foodcourtmicroservice/domain/usecases/DishUseCaseTest.java
+++ b/src/test/java/com/plazoleta/foodcourtmicroservice/domain/usecases/DishUseCaseTest.java
@@ -32,6 +32,7 @@ import com.plazoleta.foodcourtmicroservice.domain.ports.out.AuthenticatedUserPor
 import com.plazoleta.foodcourtmicroservice.domain.ports.out.DishPersistencePort;
 import com.plazoleta.foodcourtmicroservice.domain.utils.constants.DomainMessagesConstants;
 import com.plazoleta.foodcourtmicroservice.domain.validation.dish.DishValidatorChain;
+import com.plazoleta.foodcourtmicroservice.domain.validation.pagination.PaginationValidatorChain;
 
 class DishUseCaseTest {
 
@@ -49,6 +50,9 @@ class DishUseCaseTest {
     @Mock
     private AuthenticatedUserPort authenticatedUserPort;
 
+    @Mock
+    private PaginationValidatorChain paginationValidatorChain;
+
     @InjectMocks
     private DishUseCase useCase;
 
@@ -59,7 +63,7 @@ class DishUseCaseTest {
         MockitoAnnotations.openMocks(this);
         model = new DishModel(1L, "Hamburguesa", new BigDecimal("15000.00"), "Clásica hamburguesa",
                 "https://img.com/hamburguesa.jpg", 2L, buildRestaurant(10L), true);
-        useCase = new DishUseCase(persistencePort, validatorChain, authenticatedUserPort);
+        useCase = new DishUseCase(persistencePort, validatorChain, authenticatedUserPort, paginationValidatorChain);
     }
 
     @Test

--- a/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/DishValidatorChainTest.java
+++ b/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/DishValidatorChainTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import com.plazoleta.foodcourtmicroservice.domain.enums.OperationType;
 import com.plazoleta.foodcourtmicroservice.domain.exceptions.InvalidElementFormatException;
 import com.plazoleta.foodcourtmicroservice.domain.exceptions.RequiredFieldsException;
+import com.plazoleta.foodcourtmicroservice.domain.model.CategoryModel;
 import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
 import com.plazoleta.foodcourtmicroservice.domain.model.RestaurantModel;
 
@@ -22,29 +23,37 @@ class DishValidatorChainTest {
                 "https://logo.com/logo.jpg", 1L);
     }
 
+    private CategoryModel buildCategory(Long id) {
+        return new CategoryModel(id, "cat", "desc");
+    }
+
     @Test
     void when_allFieldsValid_then_noException() {
-        DishModel model = new DishModel(1L, "Pizza", new BigDecimal("10000"), "desc", "https://img.com/pizza.jpg", 2L,
+        DishModel model = new DishModel(1L, "Pizza", new BigDecimal("10000"), "desc", "https://img.com/pizza.jpg",
+                buildCategory(2L),
                 buildRestaurant(10L), true);
         assertDoesNotThrow(() -> validatorChain.validate(model, OperationType.CREATE));
     }
 
     @Test
     void when_missingRequiredField_then_throwRequiredFieldsException() {
-        DishModel model = new DishModel(1L, "name", new BigDecimal("10000"), " ", "url", 2L, buildRestaurant(10L), true);
+        DishModel model = new DishModel(1L, "name", new BigDecimal("10000"), " ", "url", buildCategory(2L),
+                buildRestaurant(10L), true);
         assertThrows(RequiredFieldsException.class, () -> validatorChain.validate(model, OperationType.CREATE));
     }
 
     @Test
     void when_invalidName_then_throwInvalidElementFormatException() {
-        DishModel model = new DishModel(1L, "   ", new BigDecimal("10000"), "desc", "url", 2L, buildRestaurant(10L),
+        DishModel model = new DishModel(1L, "   ", new BigDecimal("10000"), "desc", "url", buildCategory(2L),
+                buildRestaurant(10L),
                 true);
         assertThrows(InvalidElementFormatException.class, () -> validatorChain.validate(model, OperationType.CREATE));
     }
 
     @Test
     void when_invalidPrice_then_throwInvalidElementFormatException() {
-        DishModel model = new DishModel(1L, "Pizza", new BigDecimal("0"), "desc", "url", 2L, buildRestaurant(10L),
+        DishModel model = new DishModel(1L, "Pizza", new BigDecimal("0"), "desc", "url", buildCategory(2L),
+                buildRestaurant(10L),
                 true);
         assertThrows(InvalidElementFormatException.class, () -> validatorChain.validate(model, OperationType.CREATE));
     }

--- a/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishImageUrlValidatorTest.java
+++ b/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishImageUrlValidatorTest.java
@@ -9,11 +9,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import com.plazoleta.foodcourtmicroservice.domain.enums.OperationType;
 import com.plazoleta.foodcourtmicroservice.domain.exceptions.InvalidElementFormatException;
+import com.plazoleta.foodcourtmicroservice.domain.model.CategoryModel;
 import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
 import com.plazoleta.foodcourtmicroservice.domain.model.RestaurantModel;
-
-import com.plazoleta.foodcourtmicroservice.domain.enums.OperationType;
 
 class DishImageUrlValidatorTest {
 
@@ -24,17 +24,21 @@ class DishImageUrlValidatorTest {
                 "https://logo.com/logo.jpg", 1L);
     }
 
+    private CategoryModel buildCategory(Long id) {
+        return new CategoryModel(id, "cat", "desc");
+    }
+
     @ValueSource(strings = { "https://img.com/pizza.jpg" })
     @NullAndEmptySource
     void when_validOrEmptyOrNullImageUrl_then_noException(String imageUrl) {
-        DishModel model = new DishModel(1L, "Pizza", new BigDecimal("10000"), "desc", imageUrl, 2L,
+        DishModel model = new DishModel(1L, "Pizza", new BigDecimal("10000"), "desc", imageUrl, buildCategory(2L),
                 buildRestaurant(10L), true);
         assertDoesNotThrow(() -> validator.validate(model, OperationType.CREATE));
     }
 
     @Test
     void when_invalidImageUrl_then_throwInvalidElementFormatException() {
-        DishModel model = new DishModel(1L, "Pizza", new BigDecimal("10000"), "desc", "notaurl", 2L,
+        DishModel model = new DishModel(1L, "Pizza", new BigDecimal("10000"), "desc", "notaurl", buildCategory(2L),
                 buildRestaurant(10L), true);
         assertThrows(InvalidElementFormatException.class, () -> validator.validate(model, OperationType.CREATE));
     }

--- a/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishNameValidatorTest.java
+++ b/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishNameValidatorTest.java
@@ -1,17 +1,17 @@
 package com.plazoleta.foodcourtmicroservice.domain.validation.dish.impl;
 
-import com.plazoleta.foodcourtmicroservice.domain.model.RestaurantModel;
-
-import com.plazoleta.foodcourtmicroservice.domain.enums.OperationType;
-
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.plazoleta.foodcourtmicroservice.domain.exceptions.InvalidElementFormatException;
-import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
+import java.math.BigDecimal;
+
 import org.junit.jupiter.api.Test;
 
-import java.math.BigDecimal;
+import com.plazoleta.foodcourtmicroservice.domain.enums.OperationType;
+import com.plazoleta.foodcourtmicroservice.domain.exceptions.InvalidElementFormatException;
+import com.plazoleta.foodcourtmicroservice.domain.model.CategoryModel;
+import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
+import com.plazoleta.foodcourtmicroservice.domain.model.RestaurantModel;
 
 class DishNameValidatorTest {
     private final DishNameValidator validator = new DishNameValidator();
@@ -21,8 +21,13 @@ class DishNameValidatorTest {
                 "https://logo.com/logo.jpg", 1L);
     }
 
+    private CategoryModel buildCategory(Long id) {
+        return new CategoryModel(id, "cat", "desc");
+    }
+
     void when_validName_then_noException() {
-        DishModel model = new DishModel(1L, "Pizza", new BigDecimal("10000"), "desc", "url", 2L, buildRestaurant(10L),
+        DishModel model = new DishModel(1L, "Pizza", new BigDecimal("10000"), "desc", "url", buildCategory(2L),
+                buildRestaurant(10L),
                 true);
         assertDoesNotThrow(() -> validator.validate(model, OperationType.CREATE));
     }
@@ -30,14 +35,15 @@ class DishNameValidatorTest {
     @org.junit.jupiter.params.ParameterizedTest
     @org.junit.jupiter.params.provider.ValueSource(strings = { "   " })
     void when_invalidName_then_throwInvalidElementFormatException(String invalidName) {
-        DishModel model = new DishModel(1L, invalidName, new BigDecimal("10000"), "desc", "url", 2L,
+        DishModel model = new DishModel(1L, invalidName, new BigDecimal("10000"), "desc", "url", buildCategory(2L),
                 buildRestaurant(10L), true);
         assertThrows(InvalidElementFormatException.class, () -> validator.validate(model, OperationType.CREATE));
     }
 
     @Test
     void when_nullName_then_noException() {
-        DishModel model = new DishModel(1L, null, new BigDecimal("10000"), "desc", "url", 2L, buildRestaurant(10L),
+        DishModel model = new DishModel(1L, null, new BigDecimal("10000"), "desc", "url", buildCategory(2L),
+                buildRestaurant(10L),
                 true);
         assertDoesNotThrow(() -> validator.validate(model, OperationType.CREATE));
     }

--- a/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishPriceValidatorTest.java
+++ b/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishPriceValidatorTest.java
@@ -1,17 +1,17 @@
 package com.plazoleta.foodcourtmicroservice.domain.validation.dish.impl;
 
-import com.plazoleta.foodcourtmicroservice.domain.model.RestaurantModel;
-
-import com.plazoleta.foodcourtmicroservice.domain.enums.OperationType;
-
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.plazoleta.foodcourtmicroservice.domain.exceptions.InvalidElementFormatException;
-import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
+import java.math.BigDecimal;
+
 import org.junit.jupiter.api.Test;
 
-import java.math.BigDecimal;
+import com.plazoleta.foodcourtmicroservice.domain.enums.OperationType;
+import com.plazoleta.foodcourtmicroservice.domain.exceptions.InvalidElementFormatException;
+import com.plazoleta.foodcourtmicroservice.domain.model.CategoryModel;
+import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
+import com.plazoleta.foodcourtmicroservice.domain.model.RestaurantModel;
 
 class DishPriceValidatorTest {
     private final DishPriceValidator validator = new DishPriceValidator();
@@ -21,26 +21,34 @@ class DishPriceValidatorTest {
                 "https://logo.com/logo.jpg", 1L);
     }
 
+    private CategoryModel buildCategory(Long id) {
+        return new CategoryModel(id, "cat", "desc");
+    }
+
     @Test
     void when_validPrice_then_noException() {
-        DishModel model = new DishModel(1L, "Pizza", new BigDecimal("10000"), "desc", "url", 2L, buildRestaurant(10L),
+        DishModel model = new DishModel(1L, "Pizza", new BigDecimal("10000"), "desc", "url", buildCategory(2L),
+                buildRestaurant(10L),
                 true);
         assertDoesNotThrow(() -> validator.validate(model, OperationType.CREATE));
     }
 
     @Test
     void when_priceIsZeroOrNegative_then_throwInvalidElementFormatException() {
-        DishModel zeroPrice = new DishModel(1L, "Pizza", new BigDecimal("0"), "desc", "url", 2L, buildRestaurant(10L),
+        DishModel zeroPrice = new DishModel(1L, "Pizza", new BigDecimal("0"), "desc", "url", buildCategory(2L),
+                buildRestaurant(10L),
                 true);
-        DishModel negativePrice = new DishModel(1L, "Pizza", new BigDecimal("-1"), "desc", "url", 2L,
+        DishModel negativePrice = new DishModel(1L, "Pizza", new BigDecimal("-1"), "desc", "url", buildCategory(2L),
                 buildRestaurant(10L), true);
         assertThrows(InvalidElementFormatException.class, () -> validator.validate(zeroPrice, OperationType.CREATE));
-        assertThrows(InvalidElementFormatException.class, () -> validator.validate(negativePrice, OperationType.CREATE));
+        assertThrows(InvalidElementFormatException.class,
+                () -> validator.validate(negativePrice, OperationType.CREATE));
     }
 
     @Test
     void when_priceIsNotInteger_then_throwInvalidElementFormatException() {
-        DishModel decimalPrice = new DishModel(1L, "Pizza", new BigDecimal("10000.50"), "desc", "url", 2L,
+        DishModel decimalPrice = new DishModel(1L, "Pizza", new BigDecimal("10000.50"), "desc", "url",
+                buildCategory(2L),
                 buildRestaurant(10L), true);
         assertThrows(InvalidElementFormatException.class, () -> validator.validate(decimalPrice, OperationType.CREATE));
     }

--- a/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishRequiredFieldsValidatorTest.java
+++ b/src/test/java/com/plazoleta/foodcourtmicroservice/domain/validation/dish/impl/DishRequiredFieldsValidatorTest.java
@@ -1,3 +1,4 @@
+
 package com.plazoleta.foodcourtmicroservice.domain.validation.dish.impl;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -6,65 +7,82 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.math.BigDecimal;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import com.plazoleta.foodcourtmicroservice.domain.enums.OperationType;
 import com.plazoleta.foodcourtmicroservice.domain.exceptions.RequiredFieldsException;
+import com.plazoleta.foodcourtmicroservice.domain.model.CategoryModel;
 import com.plazoleta.foodcourtmicroservice.domain.model.DishModel;
 import com.plazoleta.foodcourtmicroservice.domain.model.RestaurantModel;
-import com.plazoleta.foodcourtmicroservice.domain.enums.OperationType;
 
 class DishRequiredFieldsValidatorTest {
+
     private final DishRequiredFieldsValidator validator = new DishRequiredFieldsValidator();
 
+    private CategoryModel buildCategory(Long id) {
+        return new CategoryModel(id, "Burgers", "All burgers");
+    }
 
     private RestaurantModel buildRestaurant(Long id) {
-        return new RestaurantModel(id, "Restaurante Prueba", "NIT123", "Calle 1", "123456789", "https://logo.com/logo.jpg", 1L);
+        return new RestaurantModel(id, "Restaurante Prueba", "NIT123", "Calle 1", "123456789",
+                "https://logo.com/logo.jpg", 1L);
     }
 
     @Test
     void when_allFieldsPresent_then_noException() {
-        DishModel model = new DishModel(1L, "Hamburguesa", new BigDecimal("15000.00"), "Clásica hamburguesa", "https://img.com/hamburguesa.jpg", 10L, buildRestaurant(2L), true);
+        DishModel model = new DishModel(1L, "Hamburguesa", new BigDecimal("15000.00"), "Clásica hamburguesa",
+                "https://img.com/hamburguesa.jpg", buildCategory(10L), buildRestaurant(2L), true);
         assertDoesNotThrow(() -> validator.validate(model, OperationType.CREATE));
     }
 
     @Test
     void when_missingName_then_throwRequiredFieldsException() {
-        DishModel model = new DishModel(1L, null, new BigDecimal("15000.00"), "desc", "url", 10L, buildRestaurant(2L), true);
+        DishModel model = new DishModel(1L, null, new BigDecimal("15000.00"), "desc", "url", buildCategory(10L),
+                buildRestaurant(2L), true);
         assertThrows(RequiredFieldsException.class, () -> validator.validate(model, OperationType.CREATE));
     }
 
     @Test
     void when_missingDescription_then_throwRequiredFieldsException() {
-        DishModel model = new DishModel(1L, "Hamburguesa", new BigDecimal("15000.00"), null, "url", 10L, buildRestaurant(2L), true);
+        DishModel model = new DishModel(1L, "Hamburguesa", new BigDecimal("15000.00"), null, "url", buildCategory(10L),
+                buildRestaurant(2L), true);
         assertThrows(RequiredFieldsException.class, () -> validator.validate(model, OperationType.CREATE));
     }
 
     @Test
     void when_descriptionIsEmpty_then_throwRequiredFieldsException() {
-        DishModel model = new DishModel(1L, "Hamburguesa", new BigDecimal("15000.00"), "", "url", 10L, buildRestaurant(2L), true);
+        DishModel model = new DishModel(1L, "Hamburguesa", new BigDecimal("15000.00"), "", "url", buildCategory(10L),
+                buildRestaurant(2L), true);
         assertThrows(RequiredFieldsException.class, () -> validator.validate(model, OperationType.CREATE));
     }
 
     @Test
     void when_descriptionIsBlank_then_throwRequiredFieldsException() {
-        DishModel model = new DishModel(1L, "Hamburguesa", new BigDecimal("15000.00"), "   ", "url", 10L, buildRestaurant(2L), true);
+        DishModel model = new DishModel(1L, "Hamburguesa", new BigDecimal("15000.00"), "   ", "url", buildCategory(10L),
+                buildRestaurant(2L), true);
         assertThrows(RequiredFieldsException.class, () -> validator.validate(model, OperationType.CREATE));
     }
 
     @Test
     void when_missingRestaurant_then_throwRequiredFieldsException() {
-        DishModel model = new DishModel(1L, "Hamburguesa", new BigDecimal("15000.00"), "desc", "url", 10L, null, true);
+        DishModel model = new DishModel(1L, "Hamburguesa", new BigDecimal("15000.00"), "desc", "url",
+                buildCategory(10L), null, true);
         assertThrows(RequiredFieldsException.class, () -> validator.validate(model, OperationType.CREATE));
     }
 
     @Test
-    void when_missingCategoryId_then_throwRequiredFieldsException() {
-        DishModel model = new DishModel(1L, "Hamburguesa", new BigDecimal("15000.00"), "desc", "url", null, buildRestaurant(2L), true);
+    void when_missingCategory_then_throwRequiredFieldsException() {
+        DishModel model = new DishModel(1L, "Hamburguesa", new BigDecimal("15000.00"), "desc", "url", null,
+                buildRestaurant(2L), true);
         assertThrows(RequiredFieldsException.class, () -> validator.validate(model, OperationType.CREATE));
     }
 
     @Test
     void when_missingPrice_then_throwRequiredFieldsException() {
-        DishModel model = new DishModel(1L, "Hamburguesa", null, "desc", "url", 10L, buildRestaurant(2L), true);
+        DishModel model = new DishModel(1L, "Hamburguesa", null, "desc", "url", buildCategory(10L), buildRestaurant(2L),
+                true);
         assertThrows(RequiredFieldsException.class, () -> validator.validate(model, OperationType.CREATE));
     }
 
@@ -85,9 +103,9 @@ class DishRequiredFieldsValidatorTest {
         assertThrows(RequiredFieldsException.class, () -> validator.validate(model, OperationType.UPDATE));
     }
 
-    @org.junit.jupiter.params.ParameterizedTest
-    @org.junit.jupiter.params.provider.NullAndEmptySource
-    @org.junit.jupiter.params.provider.ValueSource(strings = {"   "})
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = { "   " })
     void when_update_invalidDescription_then_throwRequiredFieldsException(String description) {
         DishModel model = new DishModel();
         model.setPrice(new BigDecimal("12000.00"));


### PR DESCRIPTION
Implements the core solution for HU#10: listing dishes of a restaurant with pagination and category filtering as required by the user story. This feature allows clients to view restaurant menus with proper pagination controls and the ability to filter dishes by category.

**Main Implementation (HU#10):**
- Endpoint and use case to list dishes by restaurant, supporting pagination and optional category filter
- All necessary DTOs, mappers, ports, and controller logic for this functionality
- Proper pagination response with metadata (current page, total pages, total elements)

**Additional improvements to support the solution:**
- Refactored dish flow to use CategoryModel/CategoryEntity as a reference (instead of just categoryId), following hexagonal architecture best practices
- Updated all affected layers: entities, mappers, ports, use cases, DTOs, controllers, tests, and specifications
- Added category existence validation on dish creation using proper port/adapter pattern
- Achieved 100% test coverage for DishUseCase and updated all affected unit tests
- Created robust, idempotent data.sql with sample records for categories, restaurants, and dishes
- Ensured SQL init always runs on application startup

**Focus:** HU#10 implementation with supporting refactors for maintainability and data consistency.