### PR TITLE
feat: implement HU#15 - deliver order functionality

### DIFF
--- a/src/main/java/com/plazoleta/foodcourtmicroservice/application/dto/request/DeliverOrderRequest.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/application/dto/request/DeliverOrderRequest.java
@@ -1,0 +1,14 @@
+package com.plazoleta.foodcourtmicroservice.application.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+@Schema(description = "Request for delivering an order")
+public record DeliverOrderRequest(
+        @Schema(description = "Security PIN provided by the customer", example = "1234", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank(message = "Security PIN cannot be blank")
+        @Pattern(regexp = "^\\d{4}$", message = "Security PIN must be exactly 4 digits")
+        String securityPin
+) {
+}

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/application/dto/response/DeliverOrderResponse.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/application/dto/response/DeliverOrderResponse.java
@@ -1,0 +1,18 @@
+package com.plazoleta.foodcourtmicroservice.application.dto.response;
+
+import com.plazoleta.foodcourtmicroservice.domain.enums.OrderStatusEnum;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Response for delivering an order")
+public record DeliverOrderResponse(
+        @Schema(description = "Order ID", example = "1")
+        Long id,
+        
+        @Schema(description = "Updated order status", example = "DELIVERED")
+        OrderStatusEnum status,
+        
+        @Schema(description = "Success message", example = "Order delivered successfully.")
+        String message
+) {
+}

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/application/handler/OrderHandler.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/application/handler/OrderHandler.java
@@ -1,9 +1,11 @@
 package com.plazoleta.foodcourtmicroservice.application.handler;
 
 import com.plazoleta.foodcourtmicroservice.application.dto.request.CreateOrderRequest;
+import com.plazoleta.foodcourtmicroservice.application.dto.request.DeliverOrderRequest;
 import com.plazoleta.foodcourtmicroservice.application.dto.response.OrderResponse;
 import com.plazoleta.foodcourtmicroservice.application.dto.response.AssignOrderResponse;
 import com.plazoleta.foodcourtmicroservice.application.dto.response.OrderReadyResponse;
+import com.plazoleta.foodcourtmicroservice.application.dto.response.DeliverOrderResponse;
 import com.plazoleta.foodcourtmicroservice.domain.enums.OrderStatusEnum;
 import com.plazoleta.foodcourtmicroservice.domain.utils.pagination.PageInfo;
 
@@ -15,4 +17,6 @@ public interface OrderHandler {
     AssignOrderResponse assignOrderToEmployee(Long orderId);
     
     OrderReadyResponse markOrderAsReady(Long orderId);
+    
+    DeliverOrderResponse deliverOrder(Long orderId, DeliverOrderRequest request);
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/application/handler/impl/OrderHandlerImpl.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/application/handler/impl/OrderHandlerImpl.java
@@ -6,7 +6,9 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 
 import com.plazoleta.foodcourtmicroservice.application.dto.request.CreateOrderRequest;
+import com.plazoleta.foodcourtmicroservice.application.dto.request.DeliverOrderRequest;
 import com.plazoleta.foodcourtmicroservice.application.dto.response.AssignOrderResponse;
+import com.plazoleta.foodcourtmicroservice.application.dto.response.DeliverOrderResponse;
 import com.plazoleta.foodcourtmicroservice.application.dto.response.OrderReadyResponse;
 import com.plazoleta.foodcourtmicroservice.application.dto.response.OrderResponse;
 import com.plazoleta.foodcourtmicroservice.application.handler.OrderHandler;
@@ -71,5 +73,15 @@ public class OrderHandlerImpl implements OrderHandler {
                 orderModel.getId(),
                 orderModel.getStatus(),
                 ApplicationMessagesConstants.ORDER_MARKED_AS_READY_SUCCESSFULLY);
+    }
+
+    @Override
+    public DeliverOrderResponse deliverOrder(Long orderId, DeliverOrderRequest request) {
+        OrderModel orderModel = orderServicePort.deliverOrder(orderId, request.securityPin());
+
+        return new DeliverOrderResponse(
+                orderModel.getId(),
+                orderModel.getStatus(),
+                ApplicationMessagesConstants.ORDER_DELIVERED_SUCCESSFULLY);
     }
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/application/utils/constants/ApplicationMessagesConstants.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/application/utils/constants/ApplicationMessagesConstants.java
@@ -7,6 +7,7 @@ public final class ApplicationMessagesConstants {
     public static final String DISH_UPDATED_SUCCESSFULLY = "Dish updated successfully";
     public static final String ORDER_ASSIGNED_SUCCESSFULLY = "Order assigned successfully and status changed to IN_PREPARATION";
     public static final String ORDER_MARKED_AS_READY_SUCCESSFULLY = "Order marked as ready successfully and notification sent to customer.";
+    public static final String ORDER_DELIVERED_SUCCESSFULLY = "Order delivered successfully.";
 
     private ApplicationMessagesConstants() {
         throw new IllegalStateException("Utility class");

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/ports/in/OrderServicePort.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/ports/in/OrderServicePort.java
@@ -9,4 +9,5 @@ public interface OrderServicePort {
     PageInfo<OrderModel> getOrdersByRestaurantAndStatus(OrderStatusEnum status, Integer page, Integer size);
     OrderModel assignOrderToEmployeeAndChangeStatus(Long orderId);
     OrderModel markOrderAsReady(Long orderId);
+    OrderModel deliverOrder(Long orderId, String securityPin);
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/utils/constants/DomainMessagesConstants.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/utils/constants/DomainMessagesConstants.java
@@ -68,6 +68,9 @@ public final class DomainMessagesConstants {
     public static final String ORDER_NOT_IN_PREPARATION = "Order is not in IN_PREPARATION status. Only orders in preparation can be marked as ready.";
     public static final String ORDER_MARKED_AS_READY_SUCCESSFULLY = "Order marked as ready successfully and notification sent to customer.";
     public static final String SECURITY_PIN_GENERATED = "Security PIN generated for order pickup.";
+    public static final String ORDER_NOT_READY = "Order is not in READY status. Only READY orders can be delivered.";
+    public static final String INVALID_SECURITY_PIN = "Invalid security PIN. Please verify the PIN and try again.";
+    public static final String ORDER_DELIVERED_SUCCESSFULLY = "Order delivered successfully.";
 
     private DomainMessagesConstants() {
         throw new IllegalStateException("Utility class");

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/controllers/rest/OrderController.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/controllers/rest/OrderController.java
@@ -12,7 +12,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.plazoleta.foodcourtmicroservice.application.dto.request.CreateOrderRequest;
+import com.plazoleta.foodcourtmicroservice.application.dto.request.DeliverOrderRequest;
 import com.plazoleta.foodcourtmicroservice.application.dto.response.AssignOrderResponse;
+import com.plazoleta.foodcourtmicroservice.application.dto.response.DeliverOrderResponse;
 import com.plazoleta.foodcourtmicroservice.application.dto.response.OrderReadyResponse;
 import com.plazoleta.foodcourtmicroservice.application.dto.response.OrderResponse;
 import com.plazoleta.foodcourtmicroservice.application.handler.OrderHandler;
@@ -76,16 +78,16 @@ public class OrderController {
         @PatchMapping("/{orderId}/assign")
         @Operation(summary = "Assign order to employee and change status to IN_PREPARATION", description = "Allows an employee to assign themselves to a PENDING order and change its status to IN_PREPARATION")
         @ApiResponses(value = {
-                @ApiResponse(responseCode = "200", description = "Order assigned successfully", content = @Content(mediaType = "application/json", schema = @Schema(implementation = AssignOrderResponse.class))),
-                @ApiResponse(responseCode = "400", description = "Invalid order ID", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class))),
-                @ApiResponse(responseCode = "401", description = "Unauthorized - Invalid or missing authentication", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class))),
-                @ApiResponse(responseCode = "403", description = "Forbidden - User does not have EMPLOYEE role", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class))),
-                @ApiResponse(responseCode = "404", description = "Order not found or employee not associated with restaurant", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class))),
-                @ApiResponse(responseCode = "409", description = "Order is not in PENDING status or doesn't belong to employee's restaurant", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class))),
-                @ApiResponse(responseCode = "500", description = "Internal server error", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
+                        @ApiResponse(responseCode = "200", description = "Order assigned successfully", content = @Content(mediaType = "application/json", schema = @Schema(implementation = AssignOrderResponse.class))),
+                        @ApiResponse(responseCode = "400", description = "Invalid order ID", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class))),
+                        @ApiResponse(responseCode = "401", description = "Unauthorized - Invalid or missing authentication", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class))),
+                        @ApiResponse(responseCode = "403", description = "Forbidden - User does not have EMPLOYEE role", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class))),
+                        @ApiResponse(responseCode = "404", description = "Order not found or employee not associated with restaurant", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class))),
+                        @ApiResponse(responseCode = "409", description = "Order is not in PENDING status or doesn't belong to employee's restaurant", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class))),
+                        @ApiResponse(responseCode = "500", description = "Internal server error", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
         })
         public ResponseEntity<AssignOrderResponse> assignOrderToEmployee(
-                @Parameter(description = "ID of the order to assign", example = "1") @PathVariable Long orderId) {
+                        @Parameter(description = "ID of the order to assign", example = "1") @PathVariable Long orderId) {
                 AssignOrderResponse response = orderHandler.assignOrderToEmployee(orderId);
                 return ResponseEntity.status(HttpStatus.OK).body(response);
         }
@@ -93,17 +95,35 @@ public class OrderController {
         @PatchMapping("/{orderId}/ready")
         @Operation(summary = "Mark order as ready", description = "Allows an employee to mark an IN_PREPARATION order as READY and send SMS notification to customer")
         @ApiResponses(value = {
-                @ApiResponse(responseCode = "200", description = "Order marked as ready successfully", content = @Content(mediaType = "application/json", schema = @Schema(implementation = OrderReadyResponse.class))),
-                @ApiResponse(responseCode = "400", description = "Invalid order ID", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class))),
-                @ApiResponse(responseCode = "401", description = "Unauthorized - Invalid or missing authentication", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class))),
-                @ApiResponse(responseCode = "403", description = "Forbidden - User does not have EMPLOYEE role", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class))),
-                @ApiResponse(responseCode = "404", description = "Order not found or employee not associated with restaurant", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class))),
-                @ApiResponse(responseCode = "409", description = "Order is not in IN_PREPARATION status or doesn't belong to employee's restaurant", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class))),
-                @ApiResponse(responseCode = "500", description = "Internal server error", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
+                        @ApiResponse(responseCode = "200", description = "Order marked as ready successfully", content = @Content(mediaType = "application/json", schema = @Schema(implementation = OrderReadyResponse.class))),
+                        @ApiResponse(responseCode = "400", description = "Invalid order ID", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class))),
+                        @ApiResponse(responseCode = "401", description = "Unauthorized - Invalid or missing authentication", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class))),
+                        @ApiResponse(responseCode = "403", description = "Forbidden - User does not have EMPLOYEE role", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class))),
+                        @ApiResponse(responseCode = "404", description = "Order not found or employee not associated with restaurant", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class))),
+                        @ApiResponse(responseCode = "409", description = "Order is not in IN_PREPARATION status or doesn't belong to employee's restaurant", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class))),
+                        @ApiResponse(responseCode = "500", description = "Internal server error", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
         })
         public ResponseEntity<OrderReadyResponse> markOrderAsReady(
-                @Parameter(description = "ID of the order to mark as ready", example = "1") @PathVariable Long orderId) {
+                        @Parameter(description = "ID of the order to mark as ready", example = "1") @PathVariable Long orderId) {
                 OrderReadyResponse response = orderHandler.markOrderAsReady(orderId);
+                return ResponseEntity.status(HttpStatus.OK).body(response);
+        }
+
+        @PatchMapping("/{orderId}/deliver")
+        @Operation(summary = "Deliver an order", description = "Mark an order as delivered by validating the security PIN")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "200", description = "Order delivered successfully", content = @Content(mediaType = "application/json", schema = @Schema(implementation = DeliverOrderResponse.class))),
+                        @ApiResponse(responseCode = "400", description = "Invalid request or security PIN format", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class))),
+                        @ApiResponse(responseCode = "401", description = "User not authenticated", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class))),
+                        @ApiResponse(responseCode = "403", description = "User not authorized (only employees can deliver orders)", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class))),
+                        @ApiResponse(responseCode = "404", description = "Order not found or employee not associated with restaurant", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class))),
+                        @ApiResponse(responseCode = "409", description = "Order is not in READY status, doesn't belong to employee's restaurant, or invalid security PIN", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class))),
+                        @ApiResponse(responseCode = "500", description = "Internal server error", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
+        })
+        public ResponseEntity<DeliverOrderResponse> deliverOrder(
+                        @Parameter(description = "ID of the order to deliver", example = "1") @PathVariable Long orderId,
+                        @Parameter(description = "Delivery request with security PIN") @Valid @RequestBody DeliverOrderRequest request) {
+                DeliverOrderResponse response = orderHandler.deliverOrder(orderId, request);
                 return ResponseEntity.status(HttpStatus.OK).body(response);
         }
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/security/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig {
                     http.requestMatchers(HttpMethod.GET, "/api/v1/orders").hasAuthority(SecurityConstants.ROLE_EMPLOYEE);
                     http.requestMatchers(HttpMethod.PATCH, "/api/v1/orders/{orderId}/assign").hasAuthority(SecurityConstants.ROLE_EMPLOYEE);
                     http.requestMatchers(HttpMethod.PATCH, "/api/v1/orders/{orderId}/ready").hasAuthority(SecurityConstants.ROLE_EMPLOYEE);
+                    http.requestMatchers(HttpMethod.PATCH, "/api/v1/orders/{orderId}/deliver").hasAuthority(SecurityConstants.ROLE_EMPLOYEE);
 
                     http.anyRequest().denyAll();
                 })


### PR DESCRIPTION
This Pull Request adds the ability for restaurant employees to mark an order as "delivered," closing its cycle and allowing them to focus on other orders.

User Story (HU #15):
As a restaurant employee, I need to be able to mark an order as delivered to close its cycle and focus on other orders.

Implemented Acceptance Criteria:
*Only orders with "Ready" status can be transitioned to "Delivered."
*Orders in "Delivered" status cannot be changed to any status other than "Ready."
*To change the status to "Delivered," the employee must enter the security PIN sent to the customer to claim their order.
