### PR TITLE
🚀 HU#16: Cancel Order

### DIFF
--- a/src/main/java/com/plazoleta/foodcourtmicroservice/application/dto/response/CancelOrderResponse.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/application/dto/response/CancelOrderResponse.java
@@ -1,0 +1,14 @@
+package com.plazoleta.foodcourtmicroservice.application.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Response returned when an order is successfully cancelled")
+public record CancelOrderResponse(
+    @Schema(description = "Unique identifier of the cancelled order", example = "1")
+    Long orderId,
+    
+    @Schema(description = "Confirmation message about the order cancellation", 
+            example = "Order has been cancelled successfully and notification sent to customer.")
+    String message
+) {
+}

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/application/dto/response/CancelOrderResponse.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/application/dto/response/CancelOrderResponse.java
@@ -8,7 +8,7 @@ public record CancelOrderResponse(
     Long orderId,
     
     @Schema(description = "Confirmation message about the order cancellation", 
-            example = "Order has been cancelled successfully and notification sent to customer.")
+            example = "Order has been cancelled successfully.")
     String message
 ) {
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/application/handler/OrderHandler.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/application/handler/OrderHandler.java
@@ -6,6 +6,7 @@ import com.plazoleta.foodcourtmicroservice.application.dto.response.OrderRespons
 import com.plazoleta.foodcourtmicroservice.application.dto.response.AssignOrderResponse;
 import com.plazoleta.foodcourtmicroservice.application.dto.response.OrderReadyResponse;
 import com.plazoleta.foodcourtmicroservice.application.dto.response.DeliverOrderResponse;
+import com.plazoleta.foodcourtmicroservice.application.dto.response.CancelOrderResponse;
 import com.plazoleta.foodcourtmicroservice.domain.enums.OrderStatusEnum;
 import com.plazoleta.foodcourtmicroservice.domain.utils.pagination.PageInfo;
 
@@ -19,4 +20,6 @@ public interface OrderHandler {
     OrderReadyResponse markOrderAsReady(Long orderId);
     
     DeliverOrderResponse deliverOrder(Long orderId, DeliverOrderRequest request);
+    
+    CancelOrderResponse cancelOrder(Long orderId);
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/application/handler/impl/OrderHandlerImpl.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/application/handler/impl/OrderHandlerImpl.java
@@ -11,6 +11,7 @@ import com.plazoleta.foodcourtmicroservice.application.dto.response.AssignOrderR
 import com.plazoleta.foodcourtmicroservice.application.dto.response.DeliverOrderResponse;
 import com.plazoleta.foodcourtmicroservice.application.dto.response.OrderReadyResponse;
 import com.plazoleta.foodcourtmicroservice.application.dto.response.OrderResponse;
+import com.plazoleta.foodcourtmicroservice.application.dto.response.CancelOrderResponse;
 import com.plazoleta.foodcourtmicroservice.application.handler.OrderHandler;
 import com.plazoleta.foodcourtmicroservice.application.mappers.OrderRequestMapper;
 import com.plazoleta.foodcourtmicroservice.application.mappers.OrderResponseMapper;
@@ -83,5 +84,14 @@ public class OrderHandlerImpl implements OrderHandler {
                 orderModel.getId(),
                 orderModel.getStatus(),
                 ApplicationMessagesConstants.ORDER_DELIVERED_SUCCESSFULLY);
+    }
+
+    @Override
+    public CancelOrderResponse cancelOrder(Long orderId) {
+        OrderModel orderModel = orderServicePort.cancelOrder(orderId);
+
+        return new CancelOrderResponse(
+                orderModel.getId(),
+                ApplicationMessagesConstants.ORDER_CANCELLED_SUCCESSFULLY);
     }
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/application/utils/constants/ApplicationMessagesConstants.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/application/utils/constants/ApplicationMessagesConstants.java
@@ -8,6 +8,7 @@ public final class ApplicationMessagesConstants {
     public static final String ORDER_ASSIGNED_SUCCESSFULLY = "Order assigned successfully and status changed to IN_PREPARATION";
     public static final String ORDER_MARKED_AS_READY_SUCCESSFULLY = "Order marked as ready successfully and notification sent to customer.";
     public static final String ORDER_DELIVERED_SUCCESSFULLY = "Order delivered successfully.";
+    public static final String ORDER_CANCELLED_SUCCESSFULLY = "Order has been cancelled successfully and notification sent to customer.";
 
     private ApplicationMessagesConstants() {
         throw new IllegalStateException("Utility class");

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/commons/config/openapi/OpenApiConfig.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/commons/config/openapi/OpenApiConfig.java
@@ -16,16 +16,16 @@ import io.swagger.v3.oas.annotations.servers.Server;
                 title = "🍴 Foodcourt Microservice API",
                 version = "v1.0.0",
                 description = """
-                        **Microservicio de gestión de restaurantes, menús y pedidos para la plataforma Plazoleta**
+                        **Restaurant, menu and order management microservice for the Plazoleta platform**
                         
-                        Este microservicio administra restaurantes, platos y el ciclo de vida de los pedidos.
-                        Implementa arquitectura hexagonal y DDD.
+                        This microservice manages restaurants, dishes and the order lifecycle.
+                        Implements hexagonal architecture and DDD.
                         
-                        ## Características principales:
-                        - ✅ Gestión de restaurantes y menús
-                        - ✅ Validaciones de negocio robustas
-                        - ✅ Arquitectura hexagonal + DDD
-                        - ✅ Integración con microservicios de usuarios y trazabilidad
+                        ## Key Features:
+                        - ✅ Restaurant and menu management
+                        - ✅ Robust business validations
+                        - ✅ Hexagonal architecture + DDD
+                        - ✅ Integration with user and traceability microservices
                         
                         """,
                 license = @License(
@@ -35,7 +35,7 @@ import io.swagger.v3.oas.annotations.servers.Server;
         ),
         servers = {
                 @Server(
-                        description = "Desarrollo Local",
+                        description = "Local Development",
                         url = "http://localhost:8092"
                 )
         },

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/ports/in/OrderServicePort.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/ports/in/OrderServicePort.java
@@ -10,4 +10,5 @@ public interface OrderServicePort {
     OrderModel assignOrderToEmployeeAndChangeStatus(Long orderId);
     OrderModel markOrderAsReady(Long orderId);
     OrderModel deliverOrder(Long orderId, String securityPin);
+    OrderModel cancelOrder(Long orderId);
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/ports/out/NotificationServicePort.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/ports/out/NotificationServicePort.java
@@ -2,4 +2,5 @@ package com.plazoleta.foodcourtmicroservice.domain.ports.out;
 
 public interface NotificationServicePort {
     void sendOrderReadyNotification(Long orderId, String phoneNumber, String securityPin);
+    void sendOrderCancelledNotification(Long orderId, String phoneNumber);
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/utils/constants/DomainMessagesConstants.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/utils/constants/DomainMessagesConstants.java
@@ -71,6 +71,9 @@ public final class DomainMessagesConstants {
     public static final String ORDER_NOT_READY = "Order is not in READY status. Only READY orders can be delivered.";
     public static final String INVALID_SECURITY_PIN = "Invalid security PIN. Please verify the PIN and try again.";
     public static final String ORDER_DELIVERED_SUCCESSFULLY = "Order delivered successfully.";
+    public static final String ORDER_NOT_PENDING_FOR_CANCELLATION = "Lo sentimos, tu pedido ya está en preparación y no puede cancelarse";
+    public static final String ORDER_CANCELLED_SUCCESSFULLY = "Order has been cancelled successfully.";
+    public static final String ORDER_NOT_FROM_CUSTOMER = "Order does not belong to the current customer.";
 
     private DomainMessagesConstants() {
         throw new IllegalStateException("Utility class");

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/domain/utils/constants/DomainMessagesConstants.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/domain/utils/constants/DomainMessagesConstants.java
@@ -71,7 +71,7 @@ public final class DomainMessagesConstants {
     public static final String ORDER_NOT_READY = "Order is not in READY status. Only READY orders can be delivered.";
     public static final String INVALID_SECURITY_PIN = "Invalid security PIN. Please verify the PIN and try again.";
     public static final String ORDER_DELIVERED_SUCCESSFULLY = "Order delivered successfully.";
-    public static final String ORDER_NOT_PENDING_FOR_CANCELLATION = "Lo sentimos, tu pedido ya está en preparación y no puede cancelarse";
+    public static final String ORDER_NOT_PENDING_FOR_CANCELLATION = "Sorry, your order is already in preparation and cannot be cancelled.";
     public static final String ORDER_CANCELLED_SUCCESSFULLY = "Order has been cancelled successfully.";
     public static final String ORDER_NOT_FROM_CUSTOMER = "Order does not belong to the current customer.";
 

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/adapters/external/NotificationServiceAdapter.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/adapters/external/NotificationServiceAdapter.java
@@ -39,7 +39,7 @@ public class NotificationServiceAdapter implements NotificationServicePort {
     @Override
     public void sendOrderCancelledNotification(Long orderId, String phoneNumber) {
         try {
-            String message = "Your order has been cancelled successfully. Sorry for any inconvenience.";
+            String message = "Sorry, your order is already being prepared and cannot be cancelled";
 
             SendSmsRequest request = new SendSmsRequest(phoneNumber, message, null, orderId);
 

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/adapters/external/NotificationServiceAdapter.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/adapters/external/NotificationServiceAdapter.java
@@ -35,4 +35,24 @@ public class NotificationServiceAdapter implements NotificationServicePort {
             log.error("❌ Error sending SMS notification - Order: {}, Phone: {}, Error: {}", orderId, phoneNumber, e.getMessage());
         }
     }
+
+    @Override
+    public void sendOrderCancelledNotification(Long orderId, String phoneNumber) {
+        try {
+            String message = "Your order has been cancelled successfully. Sorry for any inconvenience.";
+
+            SendSmsRequest request = new SendSmsRequest(phoneNumber, message, null, orderId);
+
+            ResponseEntity<NotificationResponse> response = messagingServiceClient.sendSmsNotification(request);
+
+            if (response.getStatusCode().is2xxSuccessful()) {
+                log.info("📱 Cancellation SMS sent successfully - Order: {}, Phone: {}", orderId, phoneNumber);
+            } else {
+                log.error("❌ Failed to send cancellation SMS - Order: {}, Phone: {}, Status: {}", orderId, phoneNumber, response.getStatusCode());
+            }
+
+        } catch (Exception e) {
+            log.error("❌ Error sending cancellation SMS notification - Order: {}, Phone: {}, Error: {}", orderId, phoneNumber, e.getMessage());
+        }
+    }
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/controllers/rest/OrderController.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/controllers/rest/OrderController.java
@@ -17,6 +17,7 @@ import com.plazoleta.foodcourtmicroservice.application.dto.response.AssignOrderR
 import com.plazoleta.foodcourtmicroservice.application.dto.response.DeliverOrderResponse;
 import com.plazoleta.foodcourtmicroservice.application.dto.response.OrderReadyResponse;
 import com.plazoleta.foodcourtmicroservice.application.dto.response.OrderResponse;
+import com.plazoleta.foodcourtmicroservice.application.dto.response.CancelOrderResponse;
 import com.plazoleta.foodcourtmicroservice.application.handler.OrderHandler;
 import com.plazoleta.foodcourtmicroservice.domain.enums.OrderStatusEnum;
 import com.plazoleta.foodcourtmicroservice.domain.utils.pagination.PageInfo;
@@ -124,6 +125,23 @@ public class OrderController {
                         @Parameter(description = "ID of the order to deliver", example = "1") @PathVariable Long orderId,
                         @Parameter(description = "Delivery request with security PIN") @Valid @RequestBody DeliverOrderRequest request) {
                 DeliverOrderResponse response = orderHandler.deliverOrder(orderId, request);
+                return ResponseEntity.status(HttpStatus.OK).body(response);
+        }
+
+        @PatchMapping("/{orderId}/cancel")
+        @Operation(summary = "Cancel an order", description = "Allow a customer to cancel their PENDING order and send notification")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "200", description = "Order cancelled successfully", content = @Content(mediaType = "application/json", schema = @Schema(implementation = CancelOrderResponse.class))),
+                        @ApiResponse(responseCode = "400", description = "Invalid order ID", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class))),
+                        @ApiResponse(responseCode = "401", description = "User not authenticated", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class))),
+                        @ApiResponse(responseCode = "403", description = "User not authorized (only customers can cancel their own orders)", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class))),
+                        @ApiResponse(responseCode = "404", description = "Order not found or does not belong to the customer", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class))),
+                        @ApiResponse(responseCode = "409", description = "Order is not in PENDING status - cannot be cancelled", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class))),
+                        @ApiResponse(responseCode = "500", description = "Internal server error", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
+        })
+        public ResponseEntity<CancelOrderResponse> cancelOrder(
+                        @Parameter(description = "ID of the order to cancel", example = "1") @PathVariable Long orderId) {
+                CancelOrderResponse response = orderHandler.cancelOrder(orderId);
                 return ResponseEntity.status(HttpStatus.OK).body(response);
         }
 }

--- a/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/com/plazoleta/foodcourtmicroservice/infrastructure/security/SecurityConfig.java
@@ -41,6 +41,7 @@ public class SecurityConfig {
                     http.requestMatchers(HttpMethod.PATCH, "/api/v1/orders/{orderId}/assign").hasAuthority(SecurityConstants.ROLE_EMPLOYEE);
                     http.requestMatchers(HttpMethod.PATCH, "/api/v1/orders/{orderId}/ready").hasAuthority(SecurityConstants.ROLE_EMPLOYEE);
                     http.requestMatchers(HttpMethod.PATCH, "/api/v1/orders/{orderId}/deliver").hasAuthority(SecurityConstants.ROLE_EMPLOYEE);
+                    http.requestMatchers(HttpMethod.PATCH, "/api/v1/orders/{orderId}/cancel").hasAuthority(SecurityConstants.ROLE_CUSTOMER);
 
                     http.anyRequest().denyAll();
                 })


### PR DESCRIPTION
## 🚀 HU#16: Cancel Order

### 📋 Description

Implementation of User Story #16: **"Cancel Order"**

### ✨ Implemented Functionality

- **Endpoint**: `PATCH /api/v1/orders/{orderId}/cancel`
- **Required Role**: CUSTOMER
- **Functionality**: Allows customers to cancel orders in PENDING status. If order cannot be cancelled (not PENDING), sends SMS notification to customer.

### 🔧 Technical Changes

#### Business Logic Fixes
- **OrderUseCase**: Corrected cancelOrder logic to match acceptance criteria
- **Notification Logic**: SMS sent only when cancellation is NOT possible
- **Status Validation**: Only PENDING orders can be cancelled successfully

#### Updated Components
- **UseCase**: Fixed business logic in `OrderUseCase.cancelOrder()`
- **Constants**: Updated message to English following acceptance criteria
- **Security**: Added endpoint authorization for CUSTOMER role
- **Tests**: 6 comprehensive unit tests covering all scenarios

#### Quality Improvements
- **Documentation**: OpenAPI documentation updated to English
- **Error Handling**: Proper exception flow with SMS notifications
- **Test Coverage**: Complete coverage for all cancellation scenarios

### 🛡️ Security

- JWT authorization validation
- CUSTOMER role verification
- Customer ownership validation for orders

### 📚 Documentation

- Complete Swagger/OpenAPI documentation updated to English
- Request/response examples
- Documented error codes

### 🧪 Testing

- **Unit Tests**: 157 tests executed successfully
- **Coverage**: Complete coverage of cancel order functionality
- **Test Cases**:
  - ✅ Successful cancellation (PENDING status)
  - ✅ Order not found
  - ✅ Order not belonging to customer
  - ✅ SMS notification for IN_PREPARATION status
  - ✅ SMS notification for READY status
  - ✅ SMS notification for DELIVERED status

### 📝 Acceptance Criteria

- ✅ **AC1**: Only orders in "PENDING" status can be cancelled
- ✅ **AC2**: SMS notification sent when cancellation is not possible: "Sorry, your order is already being prepared and cannot be cancelled"

### 🔄 Business Logic

**When cancellation IS possible (PENDING status):**
- Order status changes to CANCELLED
- No SMS notification sent
- Success response returned

**When cancellation is NOT possible (other status):**
- SMS notification sent to customer
- Exception thrown with appropriate message
- Order status remains unchanged

### 📊 Files Changed
- `OrderUseCase.java` - Corrected business logic
- `DomainMessagesConstants.java` - Updated message to English
- `NotificationServiceAdapter.java` - Fixed SMS message
- `SecurityConfig.java` - Added endpoint authorization
- `CancelOrderResponse.java` - Updated DTO documentation
- `OpenApiConfig.java` - Updated to English
- `OrderUseCaseTest.java` - Added comprehensive tests